### PR TITLE
ship: document stage-0 prereqs + empty-repo guard

### DIFF
--- a/plugins/ship/skills/ship/SKILL.md
+++ b/plugins/ship/skills/ship/SKILL.md
@@ -34,6 +34,12 @@ FleetView row read it). The marker format is below each stage.
 
 ### 0 · Worktree (invisible)
 
+**Prereqs:** a git repo with a `main` branch and at least one commit (the PR-merge path
+also needs a GitHub remote; `wt merge` to local main works without one). If the repo is
+empty (no commits / no `main`), make the first commit before branching — `git add -A &&
+git commit -m "init"` — then continue. These are generic git setup, not ship's job to
+invent, but stage 0 fails on a zero-commit repo, so handle it here.
+
 Create an isolated worktree off main and enter it (the worktrunk `wt-switch-create` flow):
 
 ```


### PR DESCRIPTION
Adds a **Prereqs** note to stage 0 of the `/ship` skill and tells it to make the first commit on an empty repo instead of failing.

**Why:** a brand-new repo with zero commits breaks `wt switch --create` — there's no base branch to fork from. The fix is a one-time `git commit`, not a whole `/ship init` command. This names the generic prerequisites (git repo, `main` branch, remote for the PR path) and handles the empty-repo edge inline.

3 added lines, no behavior change for existing repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)