### PR TITLE
Batch retro improvements: statusline breadcrumb (#2) · DISCOVER live-grounding (#3) · BUILD fan-out rule (#5)

### DIFF
--- a/plugins/ship/skills/ship/SKILL.md
+++ b/plugins/ship/skills/ship/SKILL.md
@@ -69,6 +69,12 @@ never one with unmerged work. This + stage 4's teardown means ship worktrees nev
 - Invoke `superpowers:brainstorming`. PM-framed, one question at a time.
 - For any visual/UI feature, also run `impeccable` — the HTML design sprint (use `/pix`
   for imagery freely). The spec *is* the prototype.
+- **Ground the design in the *live* product, not stale artifacts.** Before designing any
+  visual feature, look at what's actually shipped — boot the app (its dev script) or open
+  the deployed URL and *see* the current surface and its real theme/CSS. In-repo mockups
+  (`design/`, old specs) drift and read as current when they're not; the running app is the
+  design source of truth. (A run once designed against a repo's old cream mockups while the
+  live product had moved to a dark terminal UI — caught only at GATE 1, the whole spec redone.)
 - Produce ONE self-contained HTML spec in the repo's docs home (`specs/` or `docs/`,
   whichever it uses) — e.g. `specs/designs/YYYY-MM-DD-<slug>.html`. Design the **whole**
   feature here — every surface and behavior Pete wants in scope — because this spec is the
@@ -104,6 +110,15 @@ never one with unmerged work. This + stage 4's teardown means ship worktrees nev
 - Invoke `superpowers:subagent-driven-development`, driven by Opus.
 - Invoke `router` to split each build task ~50/50 Opus ↔ GPT-5.5 (codex). Opus owns the
   brief, the diff review, the gates, and git. One writer per branch at a time.
+- **Single-writer vs fan-out — pick by the diff, not by reflex** (matters most under
+  ultracode, where "always orchestrate" tempts you to parallelize the build). The default is
+  one writer on the branch: right for a small, interdependent, or design-coherent feature,
+  where parallel writers just race on the shared checkout for no gain. Fan out writers (each
+  in its own worktree, merged back) ONLY when tasks are genuinely independent *and* numerous
+  enough that isolation + merge beats serialized commits — a large migration, a broad
+  mechanical sweep. The high-value place to fan out is the **review**, regardless of build
+  size: independent reviewers per dimension + adversarial verification (see REVIEW). Don't
+  parallelize 5 small edits; do parallelize 5 verifiers.
 - Apply `ponytail` posture (shortest diff, reuse, no reinvention).
 - Run `superpowers:verify-before-done` before claiming any task done — actually run it.
 - On a red test, `superpowers:systematic-debugging`.

--- a/plugins/ship/statusline.sh
+++ b/plugins/ship/statusline.sh
@@ -22,6 +22,19 @@ phase_c()    { c '38;5;245'; }   # dim gray — the phase word
 gate_c()     { c '1;38;5;214'; } # bold amber — needs you
 update_c()   { c '38;5;179'; }   # muted gold
 
+# the stage breadcrumb — design · plan · build · review, active stage lit amber.
+# Shown from design through review (and at gates), next to the brain on line 2,
+# so which stage we're in always reads — not just a single dim word.
+stage_bar() {
+  active="$1"; out=""
+  for s in design plan build review; do
+    [ -n "$out" ] && out="$out$(c '38;5;239') · $(rst)"
+    if [ "$s" = "$active" ]; then out="$out$(c '1;38;5;215')$s$(rst)"
+    else out="$out$(c '38;5;242')$s$(rst)"; fi
+  done
+  printf '%s' "$out"
+}
+
 # ---- extract data ----
 if [ "$HAS_JQ" -eq 1 ]; then
   current_dir=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // "~"' 2>/dev/null | sed "s|^$HOME|~|g")
@@ -142,12 +155,12 @@ weekly_color() {
 is_gate=0; phase=""
 if [ -n "$ship_stage" ]; then
   case "$ship_stage" in
-    gate:1*) printf "$(gate_c)✋ %s — design?$(rst)" "$ship_slug"; is_gate=1 ;;
-    gate:2*) printf "$(gate_c)✋ %s — go?$(rst)" "$ship_slug"; is_gate=1 ;;
-    discover*) printf "$(ship_c)🚢 %s$(rst)" "$ship_slug"; phase="🔍 designing" ;;
-    plan*)     printf "$(ship_c)🚢 %s$(rst)" "$ship_slug"; phase="📐 planning" ;;
-    build*)    printf "$(ship_c)🚢 %s$(rst)" "$ship_slug"; phase="🔨 building" ;;
-    review*)   printf "$(ship_c)🚢 %s$(rst)" "$ship_slug"; phase="👀 reviewing" ;;
+    gate:1*) printf "$(gate_c)✋ %s — design?$(rst)" "$ship_slug"; is_gate=1; phase="$(stage_bar design)" ;;
+    gate:2*) printf "$(gate_c)✋ %s — go?$(rst)" "$ship_slug"; is_gate=1; phase="$(stage_bar plan)" ;;
+    discover*) printf "$(ship_c)🚢 %s$(rst)" "$ship_slug"; phase="$(stage_bar design)" ;;
+    plan*)     printf "$(ship_c)🚢 %s$(rst)" "$ship_slug"; phase="$(stage_bar plan)" ;;
+    build*)    printf "$(ship_c)🚢 %s$(rst)" "$ship_slug"; phase="$(stage_bar build)" ;;
+    review*)   printf "$(ship_c)🚢 %s$(rst)" "$ship_slug"; phase="$(stage_bar review)" ;;
     *)         printf "$(ship_c)🚢 %s$(rst)" "$ship_slug" ;;
   esac
 else


### PR DESCRIPTION
Batches three ship-retro notes from the 2026-06-30 runs into one general skill change (the maintainer pattern). Separate from PR #7 (the merge-bug fix).

### #2 — statusline shows the stage breadcrumb + branch, always
`plugins/ship/statusline.sh`: replaced the single dim line-2 phase word with a persistent **`design · plan · build · review`** breadcrumb — active stage lit amber, shown next to the brain through every stage AND both gates, with the branch (slug) on line 1. The stage now always reads; before, design/plan barely registered and a gate showed only a ✋. Tested against every marker (discover/gate:1/plan/gate:2/build/review). The live `~/.claude/statusline.sh` is updated to match so it's visible now.

### #3 — DISCOVER grounds the design in the live product
`SKILL.md` DISCOVER: added a step — before designing any visual feature, boot the app or open the deployed URL and *see* the current surface; don't trust `design/` mockups that drift. (A run designed against old cream mockups while the live app had moved to a dark terminal UI — caught only at GATE 1, whole spec redone.)

### #5 — BUILD: single-writer vs fan-out
`SKILL.md` BUILD: added the rule — single writer for small/interdependent/coherent diffs (parallel writers just race the checkout); fan out writers only for large independent sweeps; **always fan out the *review***. Reconciles ultracode's "orchestrate" with ship's "one writer per branch".

**Deferred:** #4 (clickable gate button) — needs a real message-back-into-the-session mechanism, not a quick add. Note stays open.

Closes #2, closes #3, closes #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)