### PR TITLE
ship: narrate the worktree fork when running cross-repo (Stage 0)

### DIFF
--- a/plugins/ship/skills/ship/SKILL.md
+++ b/plugins/ship/skills/ship/SKILL.md
@@ -59,6 +59,17 @@ If the repo has a `.config/wt.toml`, it auto-provisions the worktree (gitignored
 files — node_modules, .env, .dev.vars — via reflink). Write the first marker:
 `printf 'discover' > <root>/.ship-stage`. Never build on main.
 
+**Cross-repo case — narrate the fork or it looks like nothing happened.** `EnterWorktree`
+only adopts worktrees of the **session's primary repo**. When ship runs against a *different*
+repo (iterating on the ship plugin itself, or any repo that isn't this session's primary),
+`EnterWorktree` silently won't take, the session cwd never moves, and the status line stays
+pinned to the primary repo — `.ship-stage` is written in the feature repo the status line
+isn't watching, so the worktree + stage are **real but invisible**. In that case: work the
+worktree by **absolute path**, and **state the forked branch + worktree path in your narration
+the moment you create it** (`forked feature/<slug> off main @ <path>`) — a blind status line
+must never make it look like nothing forked. Pete watches for the worktree from the get-go; if
+the breadcrumb can't show it, your words must.
+
 **Opportunistic tidy (anti-accumulation):** glance at `git worktree list` first and
 `wt remove <branch> -f` any worktree whose branch is already merged and its remote shows
 `[gone]` (a finished ship that wasn't torn down). Only ever touch merged+gone worktrees —


### PR DESCRIPTION
## What

When ship runs against a repo that **isn't the session's primary repo** (e.g. iterating on the ship plugin itself from a homezero-pinned session), `EnterWorktree` silently won't adopt the worktree, the session cwd never moves, and the status line stays pinned to the primary repo. The forked worktree + `.ship-stage` marker are **real but invisible** — so it looks like nothing forked, even though worktrunk did its job from the get-go.

This bit a live session: the worktree was forked off `main` correctly, both commits landed on the branch, `main` was untouched — but the status line showed `homezero/main` the whole time, and it read as "you never made a worktree."

## Fix

One paragraph in Stage 0: when ship runs cross-repo, **work by absolute path** and **state the forked branch + worktree path in narration the moment it's created** (`forked feature/<slug> off main @ <path>`). A blind status line must never make it look like nothing forked — if the breadcrumb can't show it, the words must.

No behavior change to the normal (primary-repo) path — purely closes the cross-repo visibility gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMuD5GcN3tswWq4Mj5XnMa