### PR TITLE
ship: bake agentic verification into REVIEW (the verify skill)

### DIFF
--- a/plugins/ship/skills/ship/SKILL.md
+++ b/plugins/ship/skills/ship/SKILL.md
@@ -141,6 +141,13 @@ never one with unmerged work. This + stage 4's teardown means ship worktrees nev
   walks through it on the worktree. **Never deploy to let him review, and never tell him to
   "go look at the live site"** — deploy is downstream of merge; the worktree's localhost is
   the review surface. (Non-UI change — CLI/library — show the demo/test output instead.)
+- **Prove it actually works — invoke `verify` before the card.** With the app running,
+  invoke the `verify` skill against the worktree's localhost. A fresh read-only sub-agent
+  drives the feature, screenshots the beats, and returns `works | broken | unverifiable` +
+  taste notes; verify loops-to-fix (cap ~3). **`broken` after the cap, or `unverifiable`, →
+  do NOT proceed to merge: end the turn with a `needs input:` line ("review: <feature> —
+  couldn't prove it works: <reason>") and hand Pete the verdict + evidence.** Only a `works`
+  verdict (with its screenshot storyboard + any taste notes) flows into the card below.
 - **Render a review card** from `reference/review-card.html` (contract below), write it to
   the repo's docs home (e.g. `specs/plans/review-<slug>.html`), and `open` it. Point it at
   the running localhost ("walk through it — it's already open"). **Never tell Pete to "go
@@ -206,10 +213,15 @@ Render `reference/review-card.html` filled with the meta only — PM-framed, one
 Pete reviews *this*, not the diff:
 
 - **What you got** — plain-English bullets of what now works (what it *does*, not a file list).
-- **What it looks like** — it's already **running for him at localhost** (you booted it); a
-  screenshot/mockup goes here for the record.
-- **Already checked for you** — gates/tests green, **the flow walked end-to-end (it runs)**;
-  what was NOT touched (schema / money / public surfaces). Set his risk expectation.
+- **Proof it works** — the verifier's captioned screenshot **storyboard** (start → action →
+  success) with the `works` verdict on top. This replaces a static mockup: it's evidence the
+  running feature does what was intended, organized for a glance. It's also still **running for
+  him at localhost** (you booted it). (Non-visual change — show the demo/test output instead.)
+- **Already checked for you** — gates/tests green, **the flow driven end-to-end by a fresh
+  agent (it runs)**; what was NOT touched (schema / money / public surfaces). Set his risk
+  expectation.
+- **Verifier flagged / suggested** — the verifier's taste notes ("looked off / couldn't
+  confirm"), if any. These are *reports, not work* — Pete decides: fix now / backlog / ignore.
 - **Only you can confirm** — the 1–2 things that need his eye; walk through them on the open
   localhost.
 - **Merge?** — the PR link is there for the curious, but he shouldn't need it. Merge is the

--- a/plugins/ship/skills/ship/SKILL.md
+++ b/plugins/ship/skills/ship/SKILL.md
@@ -122,11 +122,12 @@ never one with unmerged work. This + stage 4's teardown means ship worktrees nev
 - Apply `ponytail` posture (shortest diff, reuse, no reinvention).
 - Run `superpowers:verify-before-done` before claiming any task done — actually run it.
 - On a red test, `superpowers:systematic-debugging`.
-- **Before BUILD is done, walk the whole feature end-to-end yourself** — invoke `verify`:
-  boot the app and drive its *real* user paths (the spec's happy path + key edge cases),
+- **Before BUILD is done, walk the whole feature end-to-end yourself** — a quick *self-driven*
+  smoke-walk (the formal fresh-agent `verify` skill runs in REVIEW, not here — don't invoke it
+  twice): boot the app and drive its *real* user paths (the spec's happy path + key edge cases),
   not just unit tests. *You* find the breakage, never Pete. Fix what breaks (loop with
-  `systematic-debugging`); only leave BUILD once the live flow actually works. The review
-  card's "walked it end-to-end" line is a promise — keep it true.
+  `systematic-debugging`); only leave BUILD once the live flow actually works. The review card's
+  end-to-end promise ("it runs" — backed by REVIEW's verify pass) must stay true.
 - Raise a hand only for a genuine fork (PM-framed, with a rec). Pete can jump in from
   FleetView anytime.
 
@@ -147,7 +148,8 @@ never one with unmerged work. This + stage 4's teardown means ship worktrees nev
   taste notes; verify loops-to-fix (cap ~3). **`broken` after the cap, or `unverifiable`, →
   do NOT proceed to merge: end the turn with a `needs input:` line ("review: <feature> —
   couldn't prove it works: <reason>") and hand Pete the verdict + evidence.** Only a `works`
-  verdict (with its screenshot storyboard + any taste notes) flows into the card below.
+  verdict (with its screenshot storyboard + any taste notes) flows into the card below; if verify
+  crystallized an e2e spec for a core journey, name that path in "Already checked for you".
 - **Render a review card** from `reference/review-card.html` (contract below), write it to
   the repo's docs home (e.g. `specs/plans/review-<slug>.html`), and `open` it. Point it at
   the running localhost ("walk through it — it's already open"). **Never tell Pete to "go
@@ -218,8 +220,9 @@ Pete reviews *this*, not the diff:
   running feature does what was intended, organized for a glance. It's also still **running for
   him at localhost** (you booted it). (Non-visual change — show the demo/test output instead.)
 - **Already checked for you** — gates/tests green, **the flow driven end-to-end by a fresh
-  agent (it runs)**; what was NOT touched (schema / money / public surfaces). Set his risk
-  expectation.
+  agent (it runs)**, plus any **e2e spec verify committed** for a core journey (name it — that
+  path is a standing test now); what was NOT touched (schema / money / public surfaces). Set his
+  risk expectation.
 - **Verifier flagged / suggested** — the verifier's taste notes ("looked off / couldn't
   confirm"), if any. These are *reports, not work* — Pete decides: fix now / backlog / ignore.
 - **Only you can confirm** — the 1–2 things that need his eye; walk through them on the open

--- a/plugins/ship/skills/ship/reference/review-card.html
+++ b/plugins/ship/skills/ship/reference/review-card.html
@@ -35,7 +35,14 @@
   .foot{color:var(--mut);font-size:13px;margin-top:16px;text-align:center}
   code{background:#efe9dc;border-radius:5px;padding:1px 6px;font-size:13px;font-family:ui-monospace,Menlo,monospace}
   a{color:var(--amber)}
-  .thumb{width:100%;border-radius:8px;border:1px solid var(--line);margin-top:6px}
+  .vpill{display:inline-block;background:#e7f0e7;color:#2f6a3e;border:1px solid #cfe3cf;
+    border-radius:6px;padding:2px 9px;font-size:12px;font-weight:700;letter-spacing:.04em;
+    text-transform:uppercase;margin-left:8px;vertical-align:1px}
+  .storyboard{display:grid;grid-template-columns:repeat(3,1fr);gap:12px}
+  .beat{margin:0}
+  .beat img{width:100%;aspect-ratio:16/10;object-fit:cover;border:1px solid var(--line);
+    border-radius:8px;display:block}
+  .beat figcaption{font-size:12px;color:var(--slate);margin-top:6px}
 </style>
 </head>
 <body>
@@ -49,16 +56,30 @@
     <ul>{{SHIPPED_BULLETS}}</ul>
   </div>
 
-  <!-- VISUAL: include only for user-facing/visual features, else delete this card -->
+  <!-- PROOF: the verifier's storyboard. Include for any user-facing feature; for a non-visual
+       change, swap the beats for demo/test output. Repeat the beat block per screenshot. -->
   <div class="card">
-    <h2>What it looks like</h2>
-    <img class="thumb" src="{{SCREENSHOT_SRC}}" alt="result">
+    <h2>Proof it works <span class="vpill">{{VERDICT}}</span></h2>
+    <div class="storyboard">
+      <figure class="beat">
+        <img src="{{SHOT_1_SRC}}" alt="{{SHOT_1_CAP}}">
+        <figcaption>{{SHOT_1_CAP}}</figcaption>
+      </figure>
+      <!-- one beat block per screenshot: start then action then success -->
+    </div>
   </div>
 
   <div class="card">
     <h2>Already checked for you</h2>
     {{CHECKED_PILLS}}
     <p style="margin:10px 0 0;font-size:14px;color:var(--slate)">{{RISK_NOTE}}</p>
+  </div>
+
+  <!-- FLAGGED: include only if the verifier returned taste notes, else delete this card -->
+  <div class="card">
+    <h2>Verifier flagged / suggested</h2>
+    <ul>{{FLAGGED_ITEMS}}</ul>
+    <p style="margin:10px 0 0;font-size:14px;color:var(--slate)">Reports, not work — say fix now / backlog / ignore.</p>
   </div>
 
   <div class="card">

--- a/plugins/ship/skills/verify/SKILL.md
+++ b/plugins/ship/skills/verify/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: verify
+description: >
+  Prove the feature just built actually works — a fresh read-only verifier sub-agent
+  drives the running app and judges it — before anything merges. Use in ship's REVIEW
+  stage (it's invoked there automatically) or standalone when a change is ready and you
+  want proof it works: "verify this", "prove it works", "/verify". Never declares a
+  feature working off the diff alone — it drives the real app.
+user_invocable: true
+---
+
+# /verify — prove the feature works, then hand proof to REVIEW
+
+You are the **orchestrator + fixer**. Verification splits by who's best at it:
+
+- **The subjective question — "does the feature do what was intended?"** → a fresh
+  **read-only verifier sub-agent** drives the running app and judges it. It didn't write
+  the code (independence) and app-driving is verbose (context-isolation) — both pay off.
+- **Objective codified checks** (tsc / lint / unit / existing e2e) → **you** run them as a
+  regression sweep; pass/fail can't be rubber-stamped, and you need the error to fix it.
+
+**You never declare the feature works yourself — only a fresh verifier can.** Reading the
+diff and concluding "looks right" is exactly the failure this skill exists to prevent.
+
+## 1. Preconditions — the caller owns these
+
+The running app is **already up** — in ship's REVIEW the worktree's dev server is booted for
+you; standalone, boot it first and note the URL. The verifier **reuses** that stack, never
+boots its own.
+
+**The generic seam (don't cross it):** if the feature is behind auth, the **repo** must
+provide a local/test way to reach authed surfaces. verify does **not** mint sessions, bypass
+auth, or stand up infra — that's repo plumbing, and baking it in here would couple this skill
+to one app. If authed surfaces are unreachable and the repo offers no test-auth path, return
+`unverifiable` with that reason — never fake a pass.
+
+## 2. Verify the feature (delegate) → fix → re-verify (loop ≤ 3)
+
+Brief from the plan/spec file if one exists (point the verifier at it), else inline the
+acceptance criteria. Spawn a fresh **read-only** verifier sub-agent:
+
+```
+You are a read-only verifier. Do NOT edit code. Independently confirm THIS feature works by
+driving the running app with Playwright (the stack is already up at <URL>). Most new features
+have no automated spec — verify it agentically.
+
+FEATURE (what a user should now be able to do + the observable success state):
+  <intent / acceptance criteria>            (or: see plan/spec file <path>)
+HOW TO EXERCISE IT:
+  <route + steps / API call / CLI>
+AUTH (if behind login):
+  reach authed surfaces via the repo's local/test-auth path; if none exists, say so and stop.
+
+Drive the REAL flow with Playwright — walk the exact steps a user would, like clicking through
+it. Screenshot the MEANINGFUL BEATS (start → action → success), not a random dump. Judge
+observed vs expected. Return ONLY:
+
+VERDICT: works | broken | unverifiable
+EVIDENCE: ordered list of "<screenshot path> — <plain-language caption>"   (the storyboard)
+EXPECTED: <criteria>
+OBSERVED: <what actually happened>
+TASTE: <0-3 short "looked off / couldn't confirm" notes, or "none">
+```
+
+- **broken** → fix the implementation, then spawn a **fresh** verifier (never reuse the one
+  that saw the bug — it's no longer independent of the fix). Cap at ~3 rounds.
+- **still broken after the cap**, or **unverifiable** → stop and hand the verdict + evidence
+  up to the caller for Pete. Never loop forever; never merge unproven.
+
+## 3. Regression sweep — you run the codified checks; fix red directly
+
+Run the repo's `tsc` / lint / unit / existing e2e as a regression sweep. Triage failures
+(real-bug vs stale-test); **never weaken an assertion to go green.** If a fix changes feature
+behavior, re-verify (§2).
+
+## 4. Crystallize — core journeys only
+
+If the feature is a genuine **core journey** — auth, money, a primary product flow, NOT every
+small feature — write the Playwright drive you just ran out as a committed `.spec.ts` in the
+repo's e2e location, folded into the feature's own diff. Stable selectors (role/label/text;
+add a small `data-testid` only when there's no good handle — never a brittle CSS path). Most
+features: skip this — drive, prove, report, done. The standing suite stays thin: core flows,
+not a spec per micro-feature. **Running** the committed spec in the gate is the **repo's** job
+(the seam) — verify writes it, the repo wires it.
+
+## 5. Hand back proof
+
+Return to the caller: `VERDICT`, `EVIDENCE` (the ordered screenshot + caption storyboard),
+`TASTE` notes, and the crystallized spec path (or none). In ship, REVIEW lays these straight
+into the review card — the storyboard becomes "Proof it works," the taste notes become
+"Verifier flagged." Pete reviews proof, not faith.

--- a/plugins/ship/skills/verify/SKILL.md
+++ b/plugins/ship/skills/verify/SKILL.md
@@ -49,7 +49,9 @@ FEATURE (what a user should now be able to do + the observable success state):
 HOW TO EXERCISE IT:
   <route + steps / API call / CLI>
 AUTH (if behind login):
-  reach authed surfaces via the repo's local/test-auth path; if none exists, say so and stop.
+  <the repo's local/test-auth path, or 'none'>. Use ONLY that path. Do NOT mint sessions, set
+  auth cookies, log in through the real login UI, or hit a dev-login endpoint yourself. If it's
+  'none' or the path fails, return `unverifiable` and stop — never improvise a way past auth.
 
 Drive the REAL flow with Playwright — walk the exact steps a user would, like clicking through
 it. Screenshot the MEANINGFUL BEATS (start → action → success), not a random dump. Judge

--- a/specs/2026-06-30-ship-verify-design.html
+++ b/specs/2026-06-30-ship-verify-design.html
@@ -120,6 +120,61 @@
   ├─ render review card  (now carries the proof + any flags)
   └─ GATE: Pete reviews proof → merge / "fix those" / backlog</div>
 
+  <h2>How the verifier drives the app — Playwright</h2>
+  <p>
+    The driver is <strong>Playwright</strong> — already a homezero dependency, no new infra. The
+    trick is it's used <strong>two ways</strong>, which is what resolves "flexible exploration" vs.
+    "deterministic gate":
+  </p>
+  <div class="grid">
+    <div class="card">
+      <h3>① Live drive — prove the new feature</h3>
+      <p>The verifier sub-agent drives a real browser through Playwright and <strong>clicks through
+      the actual flow like a user</strong> — navigate the route, perform the feature's action,
+      observe the result. Being an agent, it finds its way even without pre-written selectors, and
+      judges <em>observed</em> vs. <em>intended</em>. It <strong>screenshots the meaningful beats</strong>
+      (start → action → success), not a random dump.</p>
+    </div>
+    <div class="card">
+      <h3>② Crystallize — the compounding net</h3>
+      <p>For a <strong>core journey</strong>, that same exploration is written out as a committed
+      Playwright <code>.spec.ts</code> — a deterministic, headless script that re-runs in the gate
+      forever after. Same tool, so "explore live" <em>becomes</em> the saved spec. That's why it
+      compounds for free, with no spec authored by hand.</p>
+    </div>
+  </div>
+  <p>
+    Playwright also captures <strong>video + trace</strong>, but those stay gitignored as debug
+    backup — the card leads with the glanceable screenshots, no video-hosting dance.
+  </p>
+
+  <h3>What "organized for PM review" means</h3>
+  <p>
+    The screenshots don't land as a folder of PNGs — they go into the review card as a
+    <strong>captioned storyboard</strong>: the verdict on top, each shot labeled in plain product
+    language. You scan a visual walkthrough, not a test log. Roughly:
+  </p>
+  <div class="card" style="background:#0b0e12">
+    <div style="display:flex;align-items:center;gap:10px;margin-bottom:12px">
+      <span class="pill ok">works</span>
+      <span class="mono" style="font-size:13px;color:#cdd9e5">Save a listing — verified by a fresh agent driving the live app</span>
+    </div>
+    <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:12px">
+      <div>
+        <div style="aspect-ratio:16/10;border:1px solid var(--line);border-radius:8px;background:linear-gradient(135deg,#161b22,#1b2230);display:flex;align-items:center;justify-content:center;color:#3a4656;font-family:var(--mono);font-size:11px">screenshot</div>
+        <div class="mono muted" style="font-size:12px;margin-top:6px">1 · Board loads</div>
+      </div>
+      <div>
+        <div style="aspect-ratio:16/10;border:1px solid var(--line);border-radius:8px;background:linear-gradient(135deg,#161b22,#1b2230);display:flex;align-items:center;justify-content:center;color:#3a4656;font-family:var(--mono);font-size:11px">screenshot</div>
+        <div class="mono muted" style="font-size:12px;margin-top:6px">2 · Clicked Save on a listing</div>
+      </div>
+      <div>
+        <div style="aspect-ratio:16/10;border:1px solid var(--line);border-radius:8px;background:linear-gradient(135deg,#161b22,#1b2230);display:flex;align-items:center;justify-content:center;color:#3a4656;font-family:var(--mono);font-size:11px">screenshot</div>
+        <div class="mono muted" style="font-size:12px;margin-top:6px">3 · Now in Saved ✓</div>
+      </div>
+    </div>
+  </div>
+
   <h2>The light compounding (kept deliberately small)</h2>
   <p>
     When a feature is a genuine <strong>core journey</strong> — not every little thing — the verifier
@@ -165,7 +220,7 @@
 
   <h2>Open planning flags (resolve at plan time, not now)</h2>
   <ul>
-    <li><b>Verifier driver tool.</b> How the sub-agent drives the browser (Playwright CLI vs the in-harness browser tools) — pick one in the plan.</li>
+    <li><b>Playwright run mode.</b> <em>Decided: Playwright</em> (live drive + crystallized <code>.spec.ts</code>). Left for the plan: whether the agent drives via the <span class="mono">playwright-cli</span> skill step-by-step or runs a throwaway script — a mechanics detail, not a tool choice.</li>
     <li><b>"Core journey" trigger.</b> The exact rule for when the verifier commits an e2e spec vs just reports — keep it simple, decide the wording in the plan.</li>
     <li><b>Evidence into HTML.</b> Screenshots referenced by relative path vs inlined as data-URIs in the review card — a rendering detail for the card edit.</li>
     <li><b>Escalation copy.</b> What the <code>needs input:</code> line says when the verifier can't prove a feature after the cap.</li>

--- a/specs/2026-06-30-ship-verify-design.html
+++ b/specs/2026-06-30-ship-verify-design.html
@@ -1,0 +1,181 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>ship · verify — design spec</title>
+<style>
+  :root{
+    --bg:#0f1216; --panel:#161b22; --panel2:#1b2230; --ink:#e6edf3; --mut:#9aa7b4;
+    --line:#2a3340; --accent:#7ee787; --amber:#f0b75e; --blue:#79c0ff; --red:#ff7b72;
+    --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6;
+       font-size:16px;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:860px;margin:0 auto;padding:48px 24px 96px}
+  .tag{display:inline-block;font-family:var(--mono);font-size:12px;letter-spacing:.06em;
+       text-transform:uppercase;color:var(--mut);border:1px solid var(--line);
+       border-radius:999px;padding:3px 10px;margin-bottom:18px}
+  h1{font-size:30px;line-height:1.2;margin:.1em 0 .2em}
+  h1 .sub{color:var(--mut);font-weight:400}
+  h2{font-size:20px;margin:42px 0 12px;padding-bottom:8px;border-bottom:1px solid var(--line)}
+  h3{font-size:16px;margin:24px 0 6px;color:var(--blue)}
+  p{margin:10px 0}
+  .lead{font-size:18px;color:#cdd9e5;background:var(--panel);border:1px solid var(--line);
+        border-left:3px solid var(--accent);border-radius:10px;padding:18px 20px;margin:22px 0}
+  ul,ol{margin:10px 0;padding-left:22px}
+  li{margin:6px 0}
+  code{font-family:var(--mono);font-size:.88em;background:#0b0e12;border:1px solid var(--line);
+       border-radius:5px;padding:1px 6px;color:#d9e1e8}
+  .mono{font-family:var(--mono)}
+  .grid{display:grid;gap:14px;margin:18px 0}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:18px 20px}
+  .card h3{margin-top:0}
+  .num{display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;
+       border-radius:7px;background:var(--panel2);border:1px solid var(--line);color:var(--accent);
+       font-family:var(--mono);font-size:13px;margin-right:8px;vertical-align:2px}
+  .flow{font-family:var(--mono);font-size:13.5px;color:#cdd9e5;background:#0b0e12;
+        border:1px solid var(--line);border-radius:10px;padding:16px 18px;white-space:pre-wrap;overflow-x:auto}
+  .pill{font-family:var(--mono);font-size:12px;border-radius:6px;padding:1px 7px}
+  .ok{color:#0b0e12;background:var(--accent)} .bad{color:#0b0e12;background:var(--red)}
+  .seam{border-left:3px solid var(--blue)} .out{border-left:3px solid var(--red)}
+  .muted{color:var(--mut)}
+  .kv{display:grid;grid-template-columns:130px 1fr;gap:6px 16px;margin:12px 0;font-size:15px}
+  .kv b{color:var(--mut);font-weight:600}
+  table{border-collapse:collapse;width:100%;margin:16px 0;font-size:14.5px}
+  th,td{border:1px solid var(--line);padding:9px 12px;text-align:left;vertical-align:top}
+  th{background:var(--panel2);color:var(--mut);font-weight:600}
+  .foot{margin-top:48px;color:var(--mut);font-size:13px;border-top:1px solid var(--line);padding-top:16px}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <span class="tag">Design spec · ship plugin · 2026-06-30</span>
+  <h1>Bake agentic verification into <span class="mono">/ship</span><br><span class="sub">prove the feature works before the review reaches Pete</span></h1>
+
+  <div class="lead">
+    Today ship's REVIEW stage shows Pete the running app and a <em>static</em> read of the diff —
+    nothing actually <strong>drives the feature he just built</strong> and confirms it works. We add a
+    <strong>verifier</strong>: an independent sub-agent that exercises the new feature on the running app,
+    screenshots that it works, loops to fix what's broken, and lays the proof into the review card —
+    so Pete reviews <strong>evidence it works</strong>, not faith. Borrowed from the
+    <span class="mono">AI-Builder-Club/skills</span> <span class="mono">pr</span> skill; everything in this
+    spec lives inside the ship plugin (<span class="mono">peteknowsai/ship</span>).
+  </div>
+
+  <h2>Why</h2>
+  <p>
+    ship's REVIEW runs <code>/code-review</code> + <code>ponytail-review</code> (both read the
+    <em>diff</em>) and boots the worktree's localhost so Pete can walk it. The only thing judging
+    <em>"does this feature actually do what was intended"</em> is Pete's eyes. That's how the
+    skeleton-shimmer contrast bug slipped through until it was caught by hand. The missing layer:
+    an <strong>independent</strong> agent (it didn't write the code) that <strong>drives the running
+    app</strong> and returns a verdict with proof — before Pete is asked to approve.
+  </p>
+
+  <h2>What we're building — three edits, all in <span class="mono">peteknowsai/ship</span></h2>
+
+  <div class="grid">
+    <div class="card">
+      <h3><span class="num">1</span>New skill: <span class="mono">verify</span></h3>
+      <p>A focused, self-contained skill — "prove the just-built feature actually works." REVIEW
+      <em>invokes</em> it, exactly as it already invokes <code>/code-review</code> and
+      <code>ponytail-review</code>. Keeping it its own file keeps the ship skill lean and lets it be
+      run on its own. (Mirrors how AIBC made <span class="mono">pr</span> standalone.)</p>
+    </div>
+    <div class="card">
+      <h3><span class="num">2</span>Edit: <span class="mono">ship</span> REVIEW stage</h3>
+      <p>Invoke <span class="mono">verify</span> after the static reviews and <em>before</em> the
+      review card reaches Pete. Fold the verdict + screenshots + taste notes into the card. Broken
+      after the fix-loop → escalate to Pete instead of merging.</p>
+    </div>
+    <div class="card">
+      <h3><span class="num">3</span>Edit: <span class="mono">review-card.html</span></h3>
+      <p>Add a <strong>"proof it works"</strong> block (screenshots + verdict) and a
+      <strong>"verifier flagged / suggested"</strong> block, so the evidence is laid out in the one
+      HTML Pete already reads.</p>
+    </div>
+  </div>
+
+  <h2>How the <span class="mono">verify</span> skill works</h2>
+  <div class="kv">
+    <b>Who runs it</b><div>A <strong>fresh, read-only verifier sub-agent</strong> — it did not write the code, so it judges honestly, and app-driving is verbose so context-isolation pays off.</div>
+    <b>What it does</b><div>Drives the running app through the feature's acceptance criteria (pulled from the spec/plan file), <strong>screenshots the success state</strong>, and returns <span class="pill ok">works</span> / <span class="pill bad">broken</span> plus a short "this looked off" taste note.</div>
+    <b>Fix loop</b><div>broken → the ship driver (Opus) fixes → a <strong>fresh</strong> verifier re-checks. Cap ~3 rounds. The driver never rubber-stamps its own work — only a fresh verifier can call it <span class="pill ok">works</span>.</div>
+    <b>Escalation</b><div>Still broken after the cap → escalate to Pete with the verdict and evidence. It never silently merges a feature it couldn't prove.</div>
+    <b>Output</b><div>Returns <code>{ verdict, evidence paths, taste notes }</code> to REVIEW, which folds them into the review card.</div>
+  </div>
+
+  <div class="flow">REVIEW stage
+  ├─ /code-review + ponytail-review        (static — read the diff)
+  ├─ codified gate: tsc · lint · unit · e2e suite   (regression — did old stuff break?)
+  ├─ verify  ─────────────────────────────────────────────┐
+  │    fresh verifier drives the feature live             │ loop ≤ 3
+  │    works ✓  → capture screenshots + verdict           │
+  │    broken ✗ → driver fixes → fresh verifier ──────────┘
+  │    still broken → escalate to Pete
+  ├─ render review card  (now carries the proof + any flags)
+  └─ GATE: Pete reviews proof → merge / "fix those" / backlog</div>
+
+  <h2>The light compounding (kept deliberately small)</h2>
+  <p>
+    When a feature is a genuine <strong>core journey</strong> — not every little thing — the verifier
+    leaves behind <strong>one committed e2e spec</strong> for the path it just drove, folded into the
+    feature's own diff. Pete never hand-writes a spec. The standing suite is just "the critical
+    journeys that have shipped," and it's what the codified gate re-runs next time as the regression
+    net. The rule is <em>core flows only</em> — not a spec per micro-feature — so it stays a thin,
+    self-maintaining net, never a maintenance pile.
+  </p>
+
+  <h2>Pete's role at the gate (unchanged shape, better inputs)</h2>
+  <p>
+    The verifier <strong>reports; Pete directs.</strong> It never creates work on its own. At the
+    review card Pete sees proof-it-works + any flags, and says one of: <strong>merge</strong>,
+    <strong>"fix those first"</strong>, or <strong>"backlog it."</strong> Same two-gate ship shape —
+    he just no longer has to sit down and test whether the thing even works.
+  </p>
+
+  <h2>The generic seam — what ship names but does <em>not</em> build</h2>
+  <div class="card seam">
+    <p>The <span class="mono">verify</span> skill is <strong>repo-agnostic</strong>. It assumes the
+    repo hands it a <strong>reachable running app, including past auth</strong>. It does
+    <strong>not</strong> implement any auth bypass, session mint, or stack-up — that is the repo's
+    job. This single sentence is the clean seam where a repo plugs in:</p>
+    <ul>
+      <li>ship boots the worktree dev server (it already does this) and invokes <span class="mono">verify</span>.</li>
+      <li>the <strong>repo</strong> provides a local/test way to reach authed surfaces.</li>
+    </ul>
+    <p class="muted">homezero will later provide that hook (a guarded localhost login). That work is
+    <strong>out of scope here</strong> — it's a homezero task, not a ship-skill change. Keeping it out
+    is what stops the ship design and the homezero plumbing from tangling.</p>
+  </div>
+
+  <h2>Explicitly out of scope</h2>
+  <table>
+    <tr><th>Not doing</th><th>Why</th></tr>
+    <tr><td>homezero's localhost auth hook / stack-up</td><td>Separate homezero task; ship only names the requirement.</td></tr>
+    <tr><td>AIBC <span class="mono">crabbox</span> (cloud box per agent)</td><td>Solves N parallel loops; ship runs one feature at a time. No need yet.</td></tr>
+    <tr><td>AIBC <span class="mono">new-loop</span> / file-based <span class="mono">LOG.md</span> brain</td><td>ship already has a compounding memory (ship-retro loop + the router ledger). Different mechanism for a solved problem.</td></tr>
+    <tr><td>AIBC <span class="mono">setup-codebase-harness</span> / <span class="mono">dev-local</span></td><td>Repo-onboarding for cold repos; homezero is already agent-ready.</td></tr>
+    <tr><td>Uploading verifier video to a stable URL (gh prerelease)</td><td>Pete reviews the card locally; local screenshots embedded in the card are enough.</td></tr>
+  </table>
+
+  <h2>Open planning flags (resolve at plan time, not now)</h2>
+  <ul>
+    <li><b>Verifier driver tool.</b> How the sub-agent drives the browser (Playwright CLI vs the in-harness browser tools) — pick one in the plan.</li>
+    <li><b>"Core journey" trigger.</b> The exact rule for when the verifier commits an e2e spec vs just reports — keep it simple, decide the wording in the plan.</li>
+    <li><b>Evidence into HTML.</b> Screenshots referenced by relative path vs inlined as data-URIs in the review card — a rendering detail for the card edit.</li>
+    <li><b>Escalation copy.</b> What the <code>needs input:</code> line says when the verifier can't prove a feature after the cap.</li>
+  </ul>
+
+  <div class="foot">
+    ship plugin · <span class="mono">peteknowsai/ship</span> · branch <span class="mono">feature/ship-verify</span><br>
+    Source idea: <span class="mono">AI-Builder-Club/skills</span> → <span class="mono">pr</span> + <span class="mono">e2e-setup</span> skills.
+  </div>
+
+</div>
+</body>
+</html>

--- a/specs/2026-06-30-ship-verify-design.html
+++ b/specs/2026-06-30-ship-verify-design.html
@@ -40,6 +40,7 @@
         border:1px solid var(--line);border-radius:10px;padding:16px 18px;white-space:pre-wrap;overflow-x:auto}
   .pill{font-family:var(--mono);font-size:12px;border-radius:6px;padding:1px 7px}
   .ok{color:#0b0e12;background:var(--accent)} .bad{color:#0b0e12;background:var(--red)}
+  .warn{color:#0b0e12;background:var(--amber)}
   .seam{border-left:3px solid var(--blue)} .out{border-left:3px solid var(--red)}
   .muted{color:var(--mut)}
   .kv{display:grid;grid-template-columns:130px 1fr;gap:6px 16px;margin:12px 0;font-size:15px}
@@ -103,9 +104,9 @@
   <h2>How the <span class="mono">verify</span> skill works</h2>
   <div class="kv">
     <b>Who runs it</b><div>A <strong>fresh, read-only verifier sub-agent</strong> — it did not write the code, so it judges honestly, and app-driving is verbose so context-isolation pays off.</div>
-    <b>What it does</b><div>Drives the running app through the feature's acceptance criteria (pulled from the spec/plan file), <strong>screenshots the success state</strong>, and returns <span class="pill ok">works</span> / <span class="pill bad">broken</span> plus a short "this looked off" taste note.</div>
+    <b>What it does</b><div>Drives the running app through the feature's acceptance criteria (pulled from the spec/plan file), <strong>screenshots the success state</strong>, and returns <span class="pill ok">works</span> / <span class="pill bad">broken</span> / <span class="pill warn">unverifiable</span> plus a short "this looked off" taste note.</div>
     <b>Fix loop</b><div>broken → the ship driver (Opus) fixes → a <strong>fresh</strong> verifier re-checks. Cap ~3 rounds. The driver never rubber-stamps its own work — only a fresh verifier can call it <span class="pill ok">works</span>.</div>
-    <b>Escalation</b><div>Still broken after the cap → escalate to Pete with the verdict and evidence. It never silently merges a feature it couldn't prove.</div>
+    <b>Escalation</b><div>Still broken after the cap, or <span class="pill warn">unverifiable</span> (e.g. an authed surface it can't reach) → escalate to Pete with the verdict and evidence. It never silently merges a feature it couldn't prove.</div>
     <b>Output</b><div>Returns <code>{ verdict, evidence paths, taste notes }</code> to REVIEW, which folds them into the review card.</div>
   </div>
 
@@ -116,7 +117,7 @@
   │    fresh verifier drives the feature live             │ loop ≤ 3
   │    works ✓  → capture screenshots + verdict           │
   │    broken ✗ → driver fixes → fresh verifier ──────────┘
-  │    still broken → escalate to Pete
+  │    still broken (or unverifiable) → escalate to Pete
   ├─ render review card  (now carries the proof + any flags)
   └─ GATE: Pete reviews proof → merge / "fix those" / backlog</div>
 

--- a/specs/plans/2026-06-30-ship-verify.md
+++ b/specs/plans/2026-06-30-ship-verify.md
@@ -1,0 +1,318 @@
+# ship `verify` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an independent verifier to ship's REVIEW stage that drives the just-built feature on the running app via Playwright, proves it works with captioned screenshots, loops-to-fix, and lays the proof into the review card before the merge gate.
+
+**Architecture:** A new self-contained `verify` skill (REVIEW invokes it, like it already invokes `/code-review`). The skill spawns a fresh read-only verifier sub-agent that drives the running app through the feature's acceptance criteria, screenshots the beats, and returns `works|broken` + taste notes. The driver fixes broken runs and re-spawns a fresh verifier (cap ~3, then escalates to Pete). For genuine core journeys it crystallizes the exploration into a committed Playwright `.spec.ts`. The review-card template gains a proof storyboard + a "verifier flagged" block.
+
+**Tech Stack:** Claude Code skill (markdown) · Playwright (live drive + committed `.spec.ts`) · the existing ship HTML card templates.
+
+## Global Constraints
+
+- All three deliverables live **inside the ship plugin** (`peteknowsai/ship`); no homezero changes in this plan.
+- **Generic seam — verify never implements auth/stack-up.** It assumes the *caller* (ship REVIEW) has already booted the running app and that the *repo* provides a way to reach authed surfaces. verify does **not** mint sessions, bypass auth, or boot infra. This single boundary is non-negotiable — it's what keeps the skill repo-agnostic.
+- The driver (ship/Opus) **never declares the feature works itself** — only a *fresh* verifier sub-agent that didn't write the code can return `works`.
+- Fix loop is capped at **~3 rounds**; still broken → **escalate to Pete** with the verdict, never silent-merge.
+- Crystallized specs are **core journeys only** — not a spec per feature. Keep the standing suite thin.
+- This is a **skill/markdown + HTML** feature: there is no `pytest`. Each task ends with a concrete **acceptance check** (grep for the required contract, or a browser smoke-render), not a unit test. That is the honest analogue of the test cycle here.
+- Match existing file conventions: skill frontmatter shape mirrors `plugins/ship/skills/router/SKILL.md`; card markup/classes mirror the existing `review-card.html`.
+
+---
+
+## File Structure
+
+- **Create** `plugins/ship/skills/verify/SKILL.md` — the verifier skill (the whole new capability).
+- **Modify** `plugins/ship/skills/ship/SKILL.md` — Stage 4 REVIEW invokes `verify`; the "review card" contract section documents the new blocks.
+- **Modify** `plugins/ship/skills/ship/reference/review-card.html` — proof storyboard replaces the single thumb; add a "verifier flagged / suggested" block.
+
+Order matters: Task 1 creates the skill (defines the contract REVIEW depends on), Task 2 wires REVIEW to it + updates the card contract, Task 3 makes the card template carry the proof. Each is independently reviewable.
+
+---
+
+### Task 1: Author the `verify` skill
+
+**Files:**
+- Create: `plugins/ship/skills/verify/SKILL.md`
+
+**Interfaces:**
+- Produces (the contract REVIEW consumes in Task 2): the skill, when invoked, returns to its caller — `verdict` (`works`|`broken`|`unverifiable`), `evidence` (ordered list of `{path, caption}` screenshot beats), `taste_notes` (short list of "looked off / couldn't confirm" items), and `spec_committed` (path of a crystallized `.spec.ts`, or none).
+
+- [ ] **Step 1: Write the skill frontmatter + role**
+
+Create `plugins/ship/skills/verify/SKILL.md` starting with:
+
+```markdown
+---
+name: verify
+description: >
+  Prove the feature just built actually works — a fresh read-only verifier sub-agent
+  drives the running app and judges it — before anything merges. Use in ship's REVIEW
+  stage (it's invoked there automatically) or standalone when a change is ready and you
+  want proof it works: "verify this", "prove it works", "/verify". Never declares a
+  feature working off the diff alone — it drives the real app.
+user_invocable: true
+---
+
+# /verify — prove the feature works, then hand proof to REVIEW
+
+You are the **orchestrator + fixer**. Verification splits by who's best at it:
+
+- **The subjective question — "does the feature do what was intended?"** → a fresh
+  **read-only verifier sub-agent** drives the running app and judges it. It didn't write
+  the code (independence) and app-driving is verbose (context-isolation) — both pay off.
+- **Objective codified checks** (tsc / lint / unit / existing e2e) → **you** run them as a
+  regression sweep; pass/fail can't be rubber-stamped and you need the error to fix it.
+
+**You never declare the feature works yourself — only a fresh verifier can.**
+```
+
+- [ ] **Step 2: Write the "preconditions + stack" section (the generic seam)**
+
+Append:
+
+```markdown
+## 1. Preconditions (the caller owns these)
+The running app is **already up** — REVIEW booted the worktree's dev server; standalone,
+boot it first. The verifier **reuses** that stack, never boots its own. If the feature is
+behind auth, the **repo** must provide a local/test way to reach authed surfaces — verify
+does NOT mint sessions or bypass auth itself. If authed surfaces are unreachable and the
+repo offers no test-auth path, return `unverifiable` with that reason (don't fake it).
+```
+
+- [ ] **Step 3: Write the verifier sub-agent prompt (live drive via Playwright)**
+
+Append:
+
+````markdown
+## 2. Verify the feature (delegate) → fix → re-verify (loop ≤ 3)
+Brief from the plan/spec file if one exists (point the verifier at it), else inline the
+acceptance criteria. Spawn a fresh **read-only** verifier:
+
+```
+You are a read-only verifier. Do NOT edit code. Independently confirm THIS feature works by
+driving the running app with Playwright (the stack is already up at <URL>). Most new features
+have no automated spec — verify it agentically.
+
+FEATURE (what a user should now be able to do + the observable success state):
+  <intent / acceptance criteria>            (or: see plan/spec file <path>)
+HOW TO EXERCISE IT:
+  <route + steps / API call / CLI>
+AUTH (if behind login):
+  reach authed surfaces via the repo's local/test-auth path; if none exists, say so and stop.
+
+Drive the REAL flow with Playwright — walk the exact steps a user would, like clicking
+through it. Screenshot the MEANINGFUL BEATS (start → action → success), not a random dump.
+Judge observed vs expected. Return ONLY:
+
+VERDICT: works | broken | unverifiable
+EVIDENCE: ordered list of "<screenshot path> — <plain-language caption>"  (the storyboard)
+EXPECTED: <criteria>
+OBSERVED: <what actually happened>
+TASTE: <0-3 short "looked off / couldn't confirm" notes, or "none">
+```
+
+- **broken** → fix the implementation, then spawn a **fresh** verifier (never reuse the one
+  that saw the bug). Cap at ~3 rounds.
+- **still broken after the cap** → stop and hand the verdict + evidence up to the caller for
+  Pete. Never loop forever, never merge unproven.
+````
+
+- [ ] **Step 4: Write the regression sweep + crystallize sections**
+
+Append:
+
+````markdown
+## 3. Regression sweep — you run the codified checks; fix red directly
+Run the repo's `tsc` / lint / unit / existing e2e. Triage failures (real-bug vs stale-test);
+**never weaken an assertion to go green.** If a fix changes feature behavior, re-verify (§2).
+
+## 4. Crystallize — core journeys only
+If the feature is a genuine **core journey** (auth, money, a primary product flow — NOT every
+small feature), write the Playwright drive you just ran out as a committed `.spec.ts` in the
+repo's e2e location, folded into the feature's own diff. Stable selectors (role/label/text;
+add a small `data-testid` only when there's no good handle). Most features: skip this — drive,
+prove, report, done. Running the committed spec in the gate is the **repo's** job (the seam).
+
+## 5. Hand back proof
+Return to the caller: VERDICT, EVIDENCE (the ordered screenshot+caption storyboard), TASTE
+notes, and the crystallized spec path (or none). REVIEW lays these into the review card.
+````
+
+- [ ] **Step 5: Acceptance check — the contract is all present**
+
+Run:
+```bash
+cd plugins/ship/skills/verify
+grep -q 'name: verify' SKILL.md \
+ && grep -q 'read-only verifier' SKILL.md \
+ && grep -q 'VERDICT: works | broken | unverifiable' SKILL.md \
+ && grep -q 'Cap at ~3 rounds\|loop ≤ 3' SKILL.md \
+ && grep -q 'does NOT mint sessions' SKILL.md \
+ && grep -q 'core journey' SKILL.md \
+ && echo "VERIFY-SKILL CONTRACT OK" || echo "MISSING CONTRACT"
+```
+Expected: `VERIFY-SKILL CONTRACT OK`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/ship/skills/verify/SKILL.md
+git commit -m "ship: add verify skill — fresh agent proves the feature on the running app"
+```
+
+---
+
+### Task 2: Wire `verify` into REVIEW + update the card contract
+
+**Files:**
+- Modify: `plugins/ship/skills/ship/SKILL.md` (Stage 4 REVIEW, ~lines 175-201; card contract, ~lines 203-216)
+
+**Interfaces:**
+- Consumes (from Task 1): the verify skill's returned `verdict` / `evidence` / `taste_notes` / `spec_committed`.
+- Produces (Task 3 consumes): the card now carries a storyboard (evidence) + a flagged block (taste_notes).
+
+- [ ] **Step 1: Insert the verify invocation into REVIEW, before the card**
+
+In `plugins/ship/skills/ship/SKILL.md`, in Stage 4 (`### 4 · REVIEW / MERGE`), immediately after the `/code-review` + `ponytail-review` bullet and before the "Render a review card" bullet, add:
+
+```markdown
+- **Prove it actually works — invoke `verify` before the card.** After the static reviews,
+  invoke the `verify` skill against the running worktree app (you already booted it). A fresh
+  read-only sub-agent drives the feature, screenshots the beats, and returns
+  `works | broken | unverifiable` + taste notes; verify loops-to-fix (cap ~3). **`broken` after
+  the cap, or `unverifiable`, → do NOT proceed to merge: end the turn with a `needs input:` line
+  ("review: <feature> — couldn't prove it works: <reason>") and hand Pete the verdict + evidence.**
+  Only carry a `works` verdict (+ its storyboard) into the card.
+```
+
+- [ ] **Step 2: Update the "review card" contract to document the proof blocks**
+
+In the `## The review card (REVIEW artifact)` section, replace the **What it looks like** bullet and add a flagged bullet so it reads:
+
+```markdown
+- **Proof it works** — the verifier's captioned screenshot **storyboard** (start → action →
+  success) with the `works` verdict on top. This replaces a static mockup: it's evidence the
+  running feature does what was intended, organized for a glance. (Non-visual change — show the
+  demo/test output instead.)
+- **Already checked for you** — gates/tests green, **the flow driven end-to-end by a fresh
+  agent (it runs)**; what was NOT touched (schema / money / public surfaces).
+- **Verifier flagged / suggested** — the verifier's taste notes ("looked off / couldn't
+  confirm"), if any. These are *reports, not work* — Pete decides: fix now / backlog / ignore.
+- **Only you can confirm** — the 1–2 things that need his eye; walk them on the open localhost.
+```
+
+- [ ] **Step 3: Acceptance check — REVIEW invokes verify before the card, escalation documented**
+
+Run:
+```bash
+cd plugins/ship/skills/ship
+awk '/^### 4 · REVIEW/,/^### 5 · RETRO/' SKILL.md | grep -q 'invoke the `verify` skill\|invoke `verify`' \
+ && awk '/^### 4 · REVIEW/,/^### 5 · RETRO/' SKILL.md | grep -q "couldn't prove it works" \
+ && grep -q 'Proof it works' SKILL.md \
+ && grep -q 'Verifier flagged' SKILL.md \
+ && echo "REVIEW-WIRING OK" || echo "WIRING INCOMPLETE"
+```
+Expected: `REVIEW-WIRING OK`. Also eyeball: the verify bullet sits **after** static review and **before** the "Render a review card" bullet.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/ship/skills/ship/SKILL.md
+git commit -m "ship: REVIEW invokes verify before the card; card contract gains proof + flagged blocks"
+```
+
+---
+
+### Task 3: Extend the review-card template with the proof storyboard
+
+**Files:**
+- Modify: `plugins/ship/skills/ship/reference/review-card.html`
+
+**Interfaces:**
+- Consumes: the verifier evidence (`{path, caption}` beats) + taste notes, rendered by REVIEW.
+
+- [ ] **Step 1: Replace the single-thumb "What it looks like" card with a storyboard**
+
+In `review-card.html`, replace the VISUAL card (the `<div class="card">` containing
+`<h2>What it looks like</h2>` and the single `<img class="thumb">`) with a proof storyboard:
+verdict pill + a repeatable captioned beat. Use the existing CSS vars/classes where they fit;
+add minimal storyboard CSS in the `<style>` block. Mark it include-only like the current VISUAL
+card. Concretely:
+
+```html
+  <!-- PROOF: the verifier's storyboard. Include for any user-facing feature; for a non-visual
+       change, swap the beats for demo/test output. Repeat the .beat block per screenshot. -->
+  <div class="card">
+    <h2>Proof it works <span class="pill-ok">{{VERDICT}}</span></h2>
+    <div class="storyboard">
+      <figure class="beat">
+        <img src="{{SHOT_1_SRC}}" alt="{{SHOT_1_CAP}}">
+        <figcaption>{{SHOT_1_CAP}}</figcaption>
+      </figure>
+      <!-- repeat <figure class="beat"> per beat: start → action → success -->
+    </div>
+  </div>
+```
+
+Add to the `<style>` block:
+```css
+  .pill-ok{font:600 12px/1 ui-monospace,monospace;background:#1f7a3d;color:#eafff0;
+           border-radius:6px;padding:3px 8px;vertical-align:2px;margin-left:6px}
+  .storyboard{display:grid;grid-template-columns:repeat(3,1fr);gap:12px}
+  .beat{margin:0}
+  .beat img{width:100%;aspect-ratio:16/10;object-fit:cover;border:1px solid var(--line,#2a3340);
+            border-radius:8px;display:block}
+  .beat figcaption{font:12px/1.4 ui-monospace,monospace;color:#9aa7b4;margin-top:6px}
+```
+
+- [ ] **Step 2: Add the "Verifier flagged / suggested" card**
+
+Immediately after the "Already checked for you" card, add an include-only block:
+
+```html
+  <!-- FLAGGED: include only if the verifier returned taste notes, else delete this card -->
+  <div class="card">
+    <h2>Verifier flagged / suggested</h2>
+    <ul>{{FLAGGED_ITEMS}}</ul>
+    <p class="sub">Reports, not work — say fix now / backlog / ignore.</p>
+  </div>
+```
+
+- [ ] **Step 3: Acceptance check — smoke-render the card**
+
+Run:
+```bash
+cd plugins/ship/skills/ship/reference
+grep -q 'storyboard' review-card.html \
+ && grep -q '{{VERDICT}}' review-card.html \
+ && grep -q 'Verifier flagged' review-card.html \
+ && echo "CARD MARKUP OK" || echo "CARD MARKUP MISSING"
+open review-card.html   # eyeball: storyboard row + flagged card render; existing blocks intact
+```
+Expected: `CARD MARKUP OK`, and the opened card shows the storyboard row + flagged card without breaking the existing layout. (Template placeholders showing literally is expected — REVIEW fills them at render time.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/ship/skills/ship/reference/review-card.html
+git commit -m "ship: review card carries the verifier proof storyboard + flagged block"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (against `specs/2026-06-30-ship-verify-design.html`):
+- New `verify` skill → Task 1. ✓
+- REVIEW invokes verify before the card → Task 2 Step 1. ✓
+- Review-card proof storyboard + flagged blocks → Task 3 + Task 2 Step 2 (contract). ✓
+- Fresh read-only verifier, works|broken, cap-3 → escalate → Task 1 Steps 1,3 + Task 2 Step 1. ✓
+- Playwright live-drive + crystallize core journeys → Task 1 Steps 3,4. ✓
+- Screenshots organized as captioned storyboard for PM review → Task 1 Step 3 + Task 3 Step 1. ✓
+- Generic seam (repo provides runnable-past-auth app; verify implements no auth bypass) → Global Constraints + Task 1 Step 2. ✓
+- Out-of-scope kept out (no homezero auth hook, no crabbox, no loops, no video-hosting) → nothing in this plan touches them. ✓
+
+**Placeholder scan:** no "TBD/TODO/handle edge cases" — every step shows the exact markdown/HTML/commands. The `{{...}}` in the HTML are intentional render-time template slots (the existing card already uses them), not plan placeholders.
+
+**Type/name consistency:** the verifier return fields (`verdict`/`evidence`/`taste_notes`/`spec_committed`) defined in Task 1's Interfaces are the same names REVIEW consumes in Task 2 and the card renders in Task 3. `VERDICT` / storyboard "beats" / "flagged" terminology is consistent across all three tasks.


### PR DESCRIPTION
## What

Adds an **independent verifier** to ship's REVIEW stage. Before the review card reaches Pete, a fresh read-only sub-agent drives the just-built feature on the running app via **Playwright**, screenshots the beats, returns `works | broken | unverifiable`, loops-to-fix (cap ~3, else escalates), and lays the proof into the review card as a captioned storyboard. Borrowed from `AI-Builder-Club/skills`' `pr` skill; kept entirely inside the ship plugin.

## Three edits

1. **New `verify` skill** (`plugins/ship/skills/verify/SKILL.md`) — the whole capability: fresh read-only verifier, Playwright live-drive, `works|broken|unverifiable`, cap-3 fix loop, crystallize *core journeys only* into a committed `.spec.ts`. **Generic seam:** it drives an already-running app and never mints sessions / bypasses auth / boots infra — that's the repo's job (the guardrail lives in the verifier's own prompt).
2. **REVIEW invokes `verify`** before the card (`ship/SKILL.md` Stage 4); `broken`/`unverifiable` after the cap → escalate, don't merge. Card contract gains proof + flagged blocks.
3. **Review card** (`reference/review-card.html`) — proof storyboard (captioned screenshots + verdict) + a "verifier flagged / suggested" block.

## Verification

Built subagent-driven (3 tasks, acceptance checks — it's a skill/HTML feature, no unit tests). Then an **11-agent adversarial review** across 5 dimensions found **6 confirmed issues, all fixed** in `f6f638a`:
- double-invocation (BUILD's old colloquial "invoke verify" now resolved to the real skill) → BUILD reworded to an explicit self-smoke, REVIEW is the sole verify site;
- seam guardrail pulled into the verifier's own prompt (the spawned agent only sees that block);
- stale card cross-reference realigned;
- orphan crystallized-spec return field now surfaced in "Already checked for you";
- design-spec verdict vocab gains `unverifiable`.

Design spec + plan are on the branch (`specs/`). No homezero changes — the repo-side auth hook is deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMuD5GcN3tswWq4Mj5XnMa