### PR TITLE
ship: lane-aware pipeline — build on preview, merge to dev, never promote to prod

### DIFF
--- a/plugins/ship/skills/ship/SKILL.md
+++ b/plugins/ship/skills/ship/SKILL.md
@@ -61,6 +61,15 @@ is load-bearing. If the repo has a `.config/wt.toml`, it auto-provisions the wor
 files — node_modules, .env, .dev.vars — via reflink). Write the first marker:
 `printf 'discover' > <root>/.ship-stage`. Never build on main.
 
+**Isolate the branch's backend if the repo has a preview lane.** A worktree that builds against
+a *shared* backend (one Convex/DB deployment serving every branch) corrupts it — pushing this
+branch's schema reconciles the shared plane to *this* branch and drops indexes other branches
+added (the clobbering bug). So if the repo provisions a **per-branch backend**, do it now and
+point the worktree at it, so BUILD and REVIEW never touch a shared plane (homezero:
+`scripts/new-preview.sh <branch>` — spins up an isolated Convex preview seeded with real
+content, prints the deploy key + backend URL to export into the worktree; see its `## Deploy
+lanes` in AGENTS.md). No preview lane → just build against whatever dev stack the repo gives you.
+
 **Cross-repo case — narrate the fork or it looks like nothing happened.** `EnterWorktree`
 only adopts worktrees of the **session's primary repo**. When ship runs against a *different*
 repo (iterating on the ship plugin itself, or any repo that isn't this session's primary),
@@ -195,8 +204,18 @@ never one with unmerged work. This + stage 4's teardown means ship worktrees nev
     removed). **Verify with `git worktree list` — zero ship worktrees must remain. A leftover
     worktree means the teardown failed (usually the merge ran inside the worktree) — recover it
     before you declare done.**
-- If the repo auto-deploys on merge to main (CI), say so and hand back the live URL once it's
-  up; otherwise just confirm merged. Never make Pete run a deploy himself.
+- **Ship deploys to the integration lane, never to production.** After the merge, push merged
+  main to the repo's shared *dev/integration* lane if it has one — run its dev-deploy step **from
+  the main checkout** (homezero: `scripts/deploy-dev.sh`, the single serialized writer for the
+  shared dev plane; never run it from a worktree — that's the clobbering bug again), then hand
+  back that lane's URL (homezero: `dev.homezero.md`). If the repo just auto-deploys on merge via
+  CI, say so and hand back the URL once it's up; if it has no deploy step, confirm merged. Never
+  make Pete run a deploy himself.
+- **Promotion to production is NOT ship's job — shipping ends at the integration lane.**
+  "Merged" means live on *dev*, not live for users. Never deploy or promote to prod / `www`, and
+  never add a promote gate or offer to promote (homezero: `scripts/promote-to-prod.sh` is a
+  separate, human-gated ritual Pete runs on his own cadence — deliberately outside the pipeline).
+  Hand back the dev URL and stop there.
 - Run the RETRO below, then **end with a `result:` line**: what shipped, one sentence — and if
   RETRO filed a note, name it (`… · ship-retro #N filed`).
 
@@ -242,8 +261,10 @@ Pete reviews *this*, not the diff:
   confirm"), if any. These are *reports, not work* — Pete decides: fix now / backlog / ignore.
 - **Only you can confirm** — the 1–2 things that need his eye; walk through them on the open
   localhost.
-- **Merge?** — the PR link is there for the curious, but he shouldn't need it. Merge is the
-  point of no return (it deploys, if the repo auto-deploys) — only after he's seen it run.
+- **Merge?** — the PR link is there for the curious, but he shouldn't need it. Merge lands the
+  feature on the **integration lane** (dev), not on users — reversible, so it's a low-stakes yes
+  once he's seen it run. (On a repo where merge auto-deploys straight to prod, it *is* the point
+  of no return — treat it that way; but where prod is a separate promote, merge is not.)
 
 ## Gate signals — how a parked ship reaches Pete
 

--- a/plugins/ship/skills/ship/SKILL.md
+++ b/plugins/ship/skills/ship/SKILL.md
@@ -200,10 +200,12 @@ never one with unmerged work. This + stage 4's teardown means ship worktrees nev
        the *remote* branch, no checkout conflict.
     4. `git pull --ff-only` so local main matches (+ `git branch -D feature/<slug>` if the squash
        left an "unmerged" local branch behind). Nothing left on disk.
-  - Then `rm .ship-stage` and **stop the review dev server you booted** (its worktree is being
-    removed). **Verify with `git worktree list` — zero ship worktrees must remain. A leftover
-    worktree means the teardown failed (usually the merge ran inside the worktree) — recover it
-    before you declare done.**
+  - Then `rm .ship-stage`, **stop the review dev server you booted** (its worktree is being
+    removed), and **deprovision the per-branch preview backend if Stage 0 spun one up** — close
+    the resource you opened, or skip if the repo's previews auto-expire (don't leave orphaned
+    backends piling up). **Verify with `git worktree list` — zero ship worktrees must remain. A
+    leftover worktree means the teardown failed (usually the merge ran inside the worktree) —
+    recover it before you declare done.**
 - **Ship deploys to the integration lane, never to production.** After the merge, push merged
   main to the repo's shared *dev/integration* lane if it has one — run its dev-deploy step **from
   the main checkout** (homezero: `scripts/deploy-dev.sh`, the single serialized writer for the
@@ -211,10 +213,12 @@ never one with unmerged work. This + stage 4's teardown means ship worktrees nev
   back that lane's URL (homezero: `dev.homezero.md`). If the repo just auto-deploys on merge via
   CI, say so and hand back the URL once it's up; if it has no deploy step, confirm merged. Never
   make Pete run a deploy himself.
-- **Promotion to production is NOT ship's job — shipping ends at the integration lane.**
-  "Merged" means live on *dev*, not live for users. Never deploy or promote to prod / `www`, and
-  never add a promote gate or offer to promote (homezero: `scripts/promote-to-prod.sh` is a
-  separate, human-gated ritual Pete runs on his own cadence — deliberately outside the pipeline).
+- **Promotion to production is NOT ship's job — shipping ends at the integration lane.** On the
+  three-lane model this assumes (a separate prod promote), "merged" means live on *dev*, not live
+  for users — so never deploy or promote to prod / `www`, never add a promote gate or offer to
+  promote (homezero: `scripts/promote-to-prod.sh` is a separate, human-gated ritual Pete runs on
+  his own cadence — deliberately outside the pipeline). (Only where merge auto-deploys straight to
+  prod is a merge itself the user-facing release — the review-card "Merge?" line covers that case.)
   Hand back the dev URL and stop there.
 - Run the RETRO below, then **end with a `result:` line**: what shipped, one sentence — and if
   RETRO filed a note, name it (`… · ship-retro #N filed`).
@@ -262,9 +266,9 @@ Pete reviews *this*, not the diff:
 - **Only you can confirm** — the 1–2 things that need his eye; walk through them on the open
   localhost.
 - **Merge?** — the PR link is there for the curious, but he shouldn't need it. Merge lands the
-  feature on the **integration lane** (dev), not on users — reversible, so it's a low-stakes yes
-  once he's seen it run. (On a repo where merge auto-deploys straight to prod, it *is* the point
-  of no return — treat it that way; but where prod is a separate promote, merge is not.)
+  feature on the **integration lane** (dev where the repo has one, else just main) — not on
+  users, so it's a reversible, low-stakes yes once he's seen it run. (Only where merge
+  auto-deploys straight to prod is it the point of no return — treat it that way there.)
 
 ## Gate signals — how a parked ship reaches Pete
 
@@ -314,4 +318,6 @@ specced feature into "Ship 1 of N" and stopping (phasing is Pete's to request, n
 to impose). No `executing-plans` (checkpoint-heavy — the opposite of hands-off). No strict
 TDD by default (tests are a build deliverable; the pre-merge test gate is the backstop;
 reserve test-first for money/auth). No manual git worktree management — `wt` owns the
-worktree birth-to-death.
+worktree birth-to-death. No promoting to production — ship ends at the integration lane (dev);
+promotion to prod / `www` is a separate, human-gated ritual Pete runs, never ship's to deploy,
+gate, or offer.


### PR DESCRIPTION
## What

homezero landed a three-lane deploy topology (**preview → dev → prod**). This teaches `/ship` to run inside it — **and to stop at dev**.

- **Stage 0** — if the repo has a per-branch backend (a *preview lane*), provision it and point the worktree at it, so BUILD/REVIEW never touch a shared backend. Kills the schema-index clobbering that N worktrees sharing one Convex deployment caused. (homezero: `scripts/new-preview.sh`.)
- **MERGE** — after the squash, deploy merged main to the shared **dev/integration** lane from the **main checkout** (homezero: `scripts/deploy-dev.sh`, the single serialized writer — never from a worktree), hand back the dev URL. Ship's finish line.
- **No prod promotion** — shipping ends at dev. `/ship` never deploys/promotes to prod/`www`, never adds a promote gate, never offers to. Promotion is a separate human-gated ritual Pete runs (homezero: `scripts/promote-to-prod.sh`) — **his explicit decision**.
- Teardown now **deprovisions the preview backend** it spun up (no orphaned resources); the review-card "Merge?" line reconciled so merge reads as a reversible dev landing, not a user-facing point of no return (except where a repo auto-deploys straight to prod).

Generic-with-homezero-example — homezero's own lane facts live in its `AGENTS.md`; this is purely the `/ship` skill. **No homezero files touched.**

## Verification

7-agent adversarial review (coherence / generic-safety / decision-fidelity, ship files only) found **4 confirmed issues, all fixed** in the second commit: the universal-vs-conditional "live for users" contradiction, the un-torn-down preview backend, the missing "no promote" non-goal, and the card copy for no-dev-lane repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMuD5GcN3tswWq4Mj5XnMa