### PR TITLE
pipeline diet: Fable 5 rewrite — principles over prescriptions, Pete's 2026-07-28 rulings landed

### DIFF
--- a/plugins/ship/skills/pipeline/SKILL.md
+++ b/plugins/ship/skills/pipeline/SKILL.md
@@ -5,668 +5,443 @@ description: Use for any code change in a product/web repo, quick fix to full fe
 
 # /ship — idea to merged, in one command
 
-You run a feature from idea to merged. Pete is heavy in DISCOVER (his taste), glances
-at one card mid-way (go), and comes back at the end. Everything between and after the
-two gates is automatic.
+You run a feature from idea to merged. Pete is heavy in DISCOVER (his taste), glances at
+a card only when it genuinely needs him, and comes back at the end. Everything else is
+automatic.
 
 **Scope is the spec — Pete's dial, not yours.** Ship builds *exactly* what the design
 spec covers: the whole thing, in one pass — one plan, one build, one review, one merge.
-If Pete wants less he specs less; if he specs a big feature you plan and build the
-*entire* feature and do not slice it down. Never decompose a specced feature into
-"Ship 1 of 4" and stop, never defer specced surfaces to a "later phase," never let the
-plan shrink the destination. A bigger spec means a bigger plan and a longer build — that
-is wanted, not a problem to manage away. Phasing is Pete's to ask for, never yours to
-impose. The models can hold a big plan; trust that.
+Never decompose a specced feature into "Ship 1 of 4," never defer specced surfaces to a
+"later phase." A bigger spec means a bigger plan and a longer build — that is wanted.
+Phasing is Pete's to ask for, never yours to impose.
+
+`reference/incidents.md` holds environment facts learned from real failed runs — consult
+the relevant section before merges, teardowns, deploys, or debugging a dispatch.
 
 ## Verbs — Pete pins the process explicitly
 
-If the invocation's first word is `express`, `design`, or `next`, that verb
-**pins the process and skips the sizing judgment below**. Anything else — bare
-`/ship <idea>` or the auto-trigger — sizes the lane exactly as today. Verbs are
-overrides, not a menu. Every verb rides the same rails as every lane: **stage 0's
-worktree off main via `wt`, never a primary checkout**.
+If the invocation's first word is `express`, `design`, or `next`, that verb **pins the
+process and skips the sizing judgment below**. Anything else — bare `/ship <idea>` or
+the auto-trigger — sizes itself. Every verb rides the same rails: **stage 0's worktree
+off main via `wt`, never a primary checkout**.
 
 **The fork is the verb's FIRST act — before any question, recon agent, or authoring
-step.** The moment a verb lands, resolve the target repo, then immediately run
-stage 0 there: `wt switch --create`, enter the worktree, write `.ship-stage`. That
-marker flip is how Pete *sees* ship engage — a verb that spawns recon or asks
-questions while still parked on main looks like nothing happened, and that's a bug,
-not a sequencing choice. One exception: `/ship next`'s board sweep is read-only —
-each *queued ship* forks as its own first act instead.
+step.** The moment a verb lands, resolve the target repo and run stage 0 there. The
+marker flip is how Pete *sees* ship engage. One exception: `/ship next`'s board sweep is
+read-only — each *queued ship* forks as its own first act instead.
 
 - **`/ship express <tweak>`** — pins EXPRESS. The verb pins ceremony *down*, never
-  safety down: if the change turns out to touch schema/auth/money or a taste call,
-  promote per the mid-flight rule regardless of the pin.
+  safety down: a money path or a taste call promotes per the mid-flight rule regardless.
 - **`/ship design <idea>`** — pins GATED and mandates the full design walkthrough in
-  DISCOVER: clarifying questions one at a time, 2–3 approaches with a recommendation,
-  the HTML spec with a live mockup, GATE 1 — then the normal pipeline through to dev.
-  The verb is Pete asserting taste is in play; never downgrade it to SELF-DIRECTED
-  however mechanical the work looks.
+  DISCOVER. The verb is Pete asserting taste is in play; never downgrade it, however
+  mechanical the work looks.
 - **`/ship next`** — ship the board's **Next column** as one batch (board-backed repos
-  only; no board → say so and stop). Moving a card to Next is Pete's "build this"
-  signal; this verb is how the column gets worked:
-  1. **Sweep + enrich.** Pull every Next card. Bring each up to the backlog skill's
-     standard anatomy (What / Why / Done when) from card context + the repo before
-     judging it — a thin ticket enriched now is a ship that doesn't stall later.
-  2. **Triage** each card, Fable's judgment: **ship-now** (intent clear, no taste
-     call — the spec is inferable), **needs-design** (Pete's taste or direction
-     genuinely in play — same test as the GATED lane), or **too-thin** (can't design
-     it without Pete). Narrate the three lists before firing anything.
+  only; no board → say so and stop):
+  1. **Sweep + enrich.** Pull every Next card; bring each up to standard anatomy
+     (What / Why / Done when) from card context + the repo before judging it.
+  2. **Triage** into **ship-now** (spec inferable, no taste call), **needs-design**
+     (Pete's taste genuinely in play — same test as the GATED lane), or **too-thin**
+     (can't design it without Pete). Narrate the three lists before firing anything.
   3. **Fire ship-now as a sequential queue** — one ship at a time, each a normal lane
-     run with its own worktree, full pipeline, own card flow (In Progress → … →
-     For Review). **Never a parallel swarm**: merges serialize onto main, one preview
-     backend at a time, and a failed ship parks that card (comment why) and moves to
-     the next — one bad ticket never stalls the queue.
-  4. **Bulk GATE 1 for needs-design: ONE design doc, one sitting.** A single HTML —
-     a section per ticket: proposed direction, mockup where visual, and the one
-     question that matters. Publish to the specs host, comment the link on each
-     ticket, present it once. **Pete's section-by-section approval is the only human
-     gate in the batch** — approved sections run straight through (plan machine-facing,
-     no per-ticket go-card; the For Review column + dev lane are the net) and join the
-     queue. Sections he redirects get revised and re-presented; nothing builds on a guess.
-  5. **Too-thin cards** stay in Next: comment the one clarifying question on each and
-     name them in narration. They ship on a later `/ship next`, once answered.
+     run with its own worktree and card flow. **Never a parallel swarm**: merges
+     serialize onto main, one preview backend at a time; a failed ship parks its card
+     (comment why) and the queue moves on.
+  4. **Bulk GATE 1 for needs-design: ONE design doc, one sitting** — a single HTML,
+     a section per ticket (direction, mockup where visual, the one question that
+     matters). Publish, link on each ticket, present once. Approved sections run
+     straight through; redirected ones get revised. Nothing builds on a guess.
+  5. **Too-thin cards** stay in Next with one clarifying question commented.
   End with a batch `result:` line: `shipped N · awaiting design answers M · too thin K`.
 
-## Sizing — every change ships; you pick the ceremony, and gates exist only for Pete's taste
+## Sizing — every change ships; you pick the ceremony
 
-The rails are constant: worktree off main → change → prove it → merge → dev lane —
-**nothing ever edits main directly, however tiny, and Pete does nothing unless a
-gate genuinely needs him.** What scales is the ceremony, and **you size it, not
-Pete** — he asks for what he wants; you figure out what that takes. Three lanes:
+The rails are constant: worktree off main → change → prove it → merge via PR → dev
+lane — **nothing ever edits main directly, however tiny, and Pete does nothing unless a
+gate genuinely needs him.** What scales is the ceremony, and **you size it, not Pete**:
 
-- **EXPRESS — a quick tweak or fix.** Whole diff visible before you start, no
-  schema/auth/money. No spec, no plan, no cards, no stops: worktree → change → repo
-  gates (tsc/tests) → self-drive the affected flow → `wt merge` → dev lane →
-  `result:` line. Bring a dab of `ponytail` (smallest diff that works) and, for
-  anything visual, a dab of `impeccable` (the tweak should look intentional, not
-  patched). Pete finds out it's done from the `result:` line, not before.
-- **SELF-DIRECTED — real work that doesn't need Pete's eye.** Too big to freehand,
-  but no product-direction or taste question in it: write whatever spec/plan *you*
-  need to build it well (machine-facing, in the docs home, `ponytail` as waste
-  critic; `impeccable` posture for any visual surface) — then build, run the REVIEW
-  machinery (codex adversarial review + `verify` — a `works` verdict is the merge bar), merge,
-  deploy to dev, `result:` line. **Zero stops — the artifacts are for the record,
-  not for approval.**
+- **EXPRESS — a quick tweak or fix.** Whole diff visible before you start, no money
+  path. No spec, no plan, no cards, no stops: worktree → change → repo gates
+  (tsc/tests) → self-drive the affected flow → fast PR, merged on green → dev lane →
+  `result:` line. A dab of `ponytail` (smallest diff), and `impeccable` for anything
+  visual. Pete finds out from the `result:` line, not before.
+- **SELF-DIRECTED — real work with no taste question in it.** Write whatever
+  machine-facing spec/plan *you* need to build it well, then build, run the full REVIEW
+  machinery (codex review + `verify` — a `works` verdict is the merge bar), merge,
+  deploy to dev, `result:`. **Zero stops — the artifacts are for the record, not
+  approval.**
 - **GATED — Pete's taste or direction is genuinely in play.** A new user-facing
-  surface, visual identity, a product tradeoff, ambiguous scope, schema/auth/money —
-  the two-gate pipeline below, unchanged.
+  surface, visual identity, a product tradeoff, ambiguous scope, a money path — the
+  gated pipeline below.
 
 **The gate test is never size — it's whether Pete's answer would change what gets
-built** (or the change is risky/irreversible). If his input wouldn't change the
-outcome, don't stop; if it would, gate — that's the whole reason gates exist.
-**Autonomous lanes merge only on green gates + a `works` verdict** — anything less
-parks and asks instead of merging broken work. Mid-flight, promote the moment taste
-or direction appears (park, write the spec from what you've learned, present
-GATE 1); size alone just moves EXPRESS → SELF-DIRECTED, never to a gate. Never use
-an autonomous lane to slip a taste call past Pete.
+built** (or the change is risky/irreversible). If his input wouldn't change the outcome,
+don't stop. **Autonomous lanes merge only on green gates + a `works` verdict.**
+Mid-flight, promote the moment taste or direction appears (park, write the spec from
+what you've learned, present GATE 1); size alone moves EXPRESS → SELF-DIRECTED, never to
+a gate. Never use an autonomous lane to slip a taste call past Pete.
 
-**The engine ladder (conserve Fable):** the driver — Fable — is the scarcest
-inference in the pipeline; spend it only on what needs its judgment (design,
-planning, briefs, triage, gates, git — the final say). **Browser-driving goes
-to GPT-5.6 sol too (Pete's call, 2026-07-11 — it's the best at browser use):**
-verify walks, impeccable-style design QA, live-product grounding all dispatch
-as background `codex exec` — codex writes and runs its own Playwright against
-the running app and saves screenshots to disk (a bonus: file screenshots are
-exactly what the claude-in-chrome MCP couldn't reliably produce). Never drive
-Playwright/Chrome from the driver. **Auth-walled surfaces with no repo
-test-auth path: codex attaches to the codex Chrome** — the dedicated logged-in
-instance (`~/.codex/codex-chrome`, profile `~/.codex/chrome-profile`, CDP on
-:9222; Pete logs into each site there once) — via
-`chromium.connectOverCDP("http://127.0.0.1:9222")`. Only when a login exists
-solely in Pete's *personal* Chrome does a Claude subagent
-(`Agent(model: opus)`, claude-in-chrome) still fire; that is Opus's last
-remaining pipeline job.
-Heavy non-judgment inference (correctness review, mechanical recon, drafting
-code) also goes to GPT-5.6 sol per the router. Sonnet never. **One amendment
-(Pete's call, 2026-07-06): a dispatch has ~5–10 min of fixed overhead (brief,
-launch, poll, read result) — work smaller than that overhead, the driver does
-inline.** A rename, a config line, wiring a triaged review fix: dispatching it
-costs more wall-clock than doing it. Real features still go to codex;
-browser work has no inline exception — it never runs on the driver.
+## Engines
 
-**Never idle while a dispatch runs.** Waiting is the pipeline's biggest time
-sink — a codex review or browser-QA pass is 10–25 minutes, and a driver that just
-watches it wastes the whole window. While anything is dispatched, work the
-standing non-tree list (none of it violates one-writer-per-branch: the
-dispatch owns the working tree, these don't touch it): draft the review card,
-write the Linear punch-list update and closing comment, publish the spec, prep
-the commit message, groom remaining `/ship next` cards. The goal: when a
-dispatch lands, everything around it is already done — the stage closes in
-minutes. Same posture at gates: notify, then keep doing non-gated work while
-Pete decides.
+**Fable always drives — every stage, including BUILD** (Pete, 2026-07-28). The driver
+owns design, briefs, triage, gates, git, and the final say; it **dispenses the coding
+tasks to GPT-5.6 sol** via background `codex exec` (the `router` skill owns the dispatch
+mechanics and the dial). Work smaller than a dispatch's ~5–10 min fixed overhead, the
+driver writes inline. Never Sonnet.
 
-**Two principles, always:**
+**All browser work dispatches to codex too** — verify walks, design QA, live-product
+grounding: codex scripts its own Playwright against the running app and saves
+screenshots to disk; never drive Playwright/Chrome from the driver. Auth-walled
+surfaces: codex attaches to the logged-in codex Chrome (`~/.codex/codex-chrome`, CDP
+:9222) via `connectOverCDP`. Only a login that exists solely in Pete's *personal*
+Chrome still gets `Agent(model: opus)` + claude-in-chrome.
+
+**Never idle while a dispatch runs** — a codex review or QA pass is 10–25 minutes.
+Work the standing non-tree list meanwhile (draft the review card, the board update, the
+commit message, groom `/ship next` cards) so the stage closes minutes after the result
+lands. Same posture at gates: notify, then keep doing non-gated work.
+
+## Two principles, always
 
 1. **The meta rule.** Every artifact Pete sees is a condensed HTML page — he reads the
-   *meta*, never the full spec or plan. The spec (design) and the go-card are HTML he
-   opens in the browser. The execution plan is machine-facing markdown he never reads.
-   HTML artifacts follow the **html-effectiveness patterns**
-   (https://thariqs.github.io/html-effectiveness/): the thesis is that flows, options,
-   and relationships are *spatial* information markdown flattens — so lead with a
-   plain-English TL;DR, render structure as diagrams/side-by-sides instead of prose,
-   put depth behind collapsibles, and make anything visual a *live* embed, not a
-   description. Per-artifact pattern picks are named in each stage below.
-2. **Two gates, only two.** GATE 1 = design direction (after DISCOVER). GATE 2 = go
-   (after PLAN, via the go-card). Nothing else stops for him. Both gates are **HARD
-   STOPS** — present the artifact and wait; never auto-advance past them.
+   *meta*, never the full spec or plan. The spec and cards are HTML he opens in the
+   browser; the execution plan is machine-facing markdown he never reads. HTML artifacts
+   follow the **html-effectiveness patterns** (https://thariqs.github.io/html-effectiveness/):
+   plain-English TL;DR first, structure as diagrams/side-by-sides instead of prose,
+   depth behind collapsibles, anything visual a *live* embed. Pattern picks are named
+   per stage.
+2. **Two gates, at most.** GATE 1 = design direction (after DISCOVER) — always a hard
+   stop on the GATED lane. GATE 2 = go (after PLAN, via the go-card) — a hard stop
+   **only when the card carries a genuine call for Pete**: a PM tradeoff, a money path,
+   or something you judge he'd genuinely want to see before build. **A zero-call
+   go-card auto-passes** (Pete, 2026-07-28): render it, `open` it, narrate
+   "gate 2 auto-passed — nothing needed you," and keep going. Schema or auth alone
+   don't force the stop — stop only when you deem it genuinely necessary. Money paths
+   always stop. When a gate does fire, it is a **HARD STOP** — present the artifact and
+   wait.
 
-**Who Pete is:** a technical PM, not an engineer. Translate technical calls to plain
-product terms, give a recommendation, let him decide. His lane = product, design,
-taste, scope. Your lane = mechanics — handle them, summarize in one line. The
-**standing stack is never re-asked** — it's Pete's default product/web stack, declared in
-his global instructions (`~/.claude/CLAUDE.md` in Claude Code, AGENTS.md / global
-Codex instructions in Codex): flue · Cloudflare · Convex · Clerk · Stripe · Next.
-**The repo's own `CLAUDE.md` / `AGENTS.md` overrides it** when that repo diverges
-(a non-web repo declares its own stack). Escalate a library choice only when it's both
-architectural *and* outside the repo's canon.
+**Who Pete is & the stack:** his global instructions carry both (technical-PM tone dial;
+the standing stack — flue · Cloudflare · Convex · Clerk · Stripe · Next). Never re-ask
+the stack. **The repo's own `CLAUDE.md` / `AGENTS.md` overrides it** where it diverges.
+Escalate a library choice only when it's both architectural *and* outside the canon.
+
+## The ship contract — what a repo tells ship
+
+A repo declares how ship runs it in its `CLAUDE.md` / `AGENTS.md`: the **gate commands**
+(tests, typecheck, production build), the **deploy lanes** and their scripts, **per-branch
+preview provisioning** where a shared backend exists, a **test-auth path** verify may
+use, and — for repos that shouldn't ship at all (wikis, civic work) — **`ship: no`**,
+which means decline and say why. homezero's AGENTS.md is the model. A repo with no
+contract gets best-effort: whatever gates you can find, merge to main, no deploy claim.
 
 ## The pipeline — create a todo for each stage
 
 Each stage writes its marker to `.ship-stage` at the git root (the status line + the
-FleetView row read it). The marker format is below each stage.
+FleetView row read it). Written for Claude Code; a **Codex Desktop** driver applies the
+swaps in "Running under Codex Desktop" below.
 
-The pipeline below is written for Claude Code (the primary harness). When the driver
-is a **Codex Desktop** session, the same pipeline runs with different mechanics —
-see **"Running under Codex Desktop"** near the end; its swaps override the
-worktree/browser/merge specifics below.
+### 0 · Worktree (invisible)  → marker: `discover`
 
-### 0 · Worktree (invisible)
-
-**Prereqs:** a git repo with a `main` branch and at least one commit (the PR-merge path
-also needs a GitHub remote; `wt merge` to local main works without one). If the repo is
-empty (no commits / no `main`), make the first commit before branching — `git add -A &&
-git commit -m "init"` — then continue. These are generic git setup, not ship's job to
-invent, but stage 0 fails on a zero-commit repo, so handle it here.
-
-Create an isolated worktree off main and enter it (the worktrunk `wt-switch-create` flow):
+**Prereqs:** a git repo with `main` and ≥1 commit (zero-commit repo: `git add -A &&
+git commit -m "init"` first). The PR path needs a GitHub remote; a repo with no remote
+falls back to `wt merge` at merge time.
 
 ```
 wt switch --create feature/<slug> --no-cd --format=json -y
 ```
-then enter/use the path from the JSON. Claude Code: `EnterWorktree({path})`. Codex:
-set subsequent tool working directories to that path (or use absolute paths). `--no-cd`
-is load-bearing. If the repo has a `.config/wt.toml`, it auto-provisions the worktree (gitignored runtime
-files — node_modules, .env, .dev.vars — via reflink). Write the first marker:
-`printf 'discover' > <root>/.ship-stage`. Never build on main.
+then enter the path from the JSON — Claude Code: `EnterWorktree({path})`; Codex:
+absolute paths. `--no-cd` is load-bearing. A `.config/wt.toml` auto-provisions
+gitignored runtime files. Write `printf 'discover' > <root>/.ship-stage`. Never build
+on main.
 
-**Isolate the branch's backend if the repo has a preview lane.** A worktree that builds against
-a *shared* backend (one Convex/DB deployment serving every branch) corrupts it — pushing this
-branch's schema reconciles the shared plane to *this* branch and drops indexes other branches
-added (the clobbering bug). So if the repo provisions a **per-branch backend**, do it now and
-point the worktree at it, so BUILD and REVIEW never touch a shared plane (homezero:
-`scripts/new-preview.sh <branch>` — spins up an isolated Convex preview seeded with real
-content, prints the deploy key + backend URL to export into the worktree; see its `## Deploy
-lanes` in AGENTS.md). No preview lane → just build against whatever dev stack the repo gives you.
-
-**Cross-repo case — narrate the fork or it looks like nothing happened.** `EnterWorktree`
-only adopts worktrees of the **session's primary repo**. When ship runs against a *different*
-repo (iterating on the ship plugin itself, or any repo that isn't this session's primary),
-`EnterWorktree` silently won't take, the session cwd never moves, and the status line stays
-pinned to the primary repo — `.ship-stage` is written in the feature repo the status line
-isn't watching, so the worktree + stage are **real but invisible**. In that case: work the
-worktree by **absolute path**, and **state the forked branch + worktree path in your narration
-the moment you create it** (`forked feature/<slug> off main @ <path>`) — a blind status line
-must never make it look like nothing forked. Pete watches for the worktree from the get-go; if
-the breadcrumb can't show it, your words must.
-
-**Opportunistic tidy (anti-accumulation):** glance at `git worktree list` first and
-`wt remove <branch> -f` any worktree that provably already landed: its branch is merged
-with the remote showing `[gone]`, OR a **merged PR** exists for the branch whose
-`headRefOid` equals the worktree's `HEAD` with a clean tree (squash merges from the
-GitHub UI / other sessions don't delete the branch or satisfy `--merged` — check
-`gh pr list --state merged --head <branch> --json number,headRefOid`). Never touch a
-worktree with uncommitted changes or commits past the merged tip. The shipboard
-launchd loop runs this same reap continuously (board/shipboard.mjs), so cruft
-self-clears on board-backed repos — this tidy is the belt to that suspenders.
+- **Provision the per-branch backend now** if the repo's ship contract has one — a
+  worktree building against a shared backend clobbers it (incidents: Backends). No
+  preview lane → build against the repo's dev stack.
+- **Cross-repo case:** `EnterWorktree` only takes for the session's primary repo
+  (incidents: Worktrees). Against any other repo, work the worktree by **absolute
+  path** and **narrate the fork the moment you create it** (`forked feature/<slug> off
+  main @ <path>`) — a blind status line must never make it look like nothing forked.
+- **Opportunistic tidy:** glance at `git worktree list` and `wt remove <branch> -f`
+  any worktree that provably landed (merged PR whose `headRefOid` matches its HEAD,
+  clean tree — incidents: Worktrees). Never touch one with uncommitted work.
 
 ### 1 · DISCOVER — Pete's taste, up front  → marker: `discover`, then `gate:1`
 
 - Invoke `superpowers:brainstorming`. PM-framed, one question at a time.
-- **Mechanical recon runs on GPT-5.6 sol, synthesis stays with the driver.** When
-  grounding needs codebase evidence-gathering (what's the current state of X,
-  where does Y live, summarize this subsystem), dispatch a background
-  `codex exec … < /dev/null` **briefed read-only** (report findings, edit
-  nothing — see the router skill's quick-reference) instead of burning
-  Max-quota agents on reading. The driver — Fable — does the actual design and
-  every judgment call from that evidence; recon is the only part that leaves.
-- **The recon brief includes a reuse audit:** for every core noun the feature
-  introduces (a table, module, event type, helper), grep the WHOLE repo — data
-  layer included, not just the subsystem in focus — for existing infra of that
-  name before the plan treats it as new. Extend-it beats build-it (a plan once
-  specced a fresh `events` table the repo already had; three tasks got
-  rewritten mid-build).
-- **Bug-shaped requests ("X isn't working") get an empirical root-cause check
-  before the spec commits to a cause:** reproduce the failure or read the
-  actual runtime evidence (logs, live session transcripts, dependency health)
-  and write the *observed* cause with its evidence — never spec a fix from a
-  hypothesis. (A hypothesized cause once produced a fix that would have made
-  an agent fabricate data; the real cause was a 500ing dependency.)
-- For any visual/UI feature, also run `impeccable` — the HTML design sprint (use `/pix`
-  for imagery freely). The spec *is* the prototype.
-- **Ground the design in the *live* product, not stale artifacts.** Before designing any
-  visual feature, look at what's actually shipped — boot the app (its dev script) or open
-  the deployed URL and *see* the current surface and its real theme/CSS. **A background
-  codex dispatch does the driving** (browser work is GPT-5.6 sol, never the driver): it
-  scripts Playwright against the running app, walks the relevant surfaces, saves
-  screenshots to disk, and reports the real theme/CSS;
-  the driver Reads the key screenshots and designs from them. In-repo mockups
-  (`design/`, old specs) drift and read as current when they're not; the running app is the
-  design source of truth. (A run once designed against a repo's old cream mockups while the
-  live product had moved to a dark terminal UI — caught only at GATE 1, the whole spec redone.)
+- **Recon runs on codex, synthesis stays with the driver.** Codebase evidence-gathering
+  dispatches as a background read-only `codex exec` (report findings, edit nothing).
+  The recon brief includes a **reuse audit**: for every core noun the feature
+  introduces, grep the whole repo — data layer included — for existing infra before the
+  plan treats it as new (incidents: Design).
+- **Bug-shaped requests get an empirical root-cause check** — reproduce the failure or
+  read the runtime evidence; never spec a fix from a hypothesis (incidents: Design).
+- For any visual/UI feature, run `impeccable` (use `/pix` for imagery freely) — the
+  spec *is* the prototype. **Ground the design in the live product**: a background
+  codex dispatch walks the running app / deployed URL and reports the real theme/CSS
+  with screenshots; design from those, never from in-repo mockups (incidents: Design).
 - Produce ONE self-contained HTML spec in the repo's docs home (`specs/` or `docs/`,
-  whichever it uses) — e.g. `specs/designs/YYYY-MM-DD-<slug>.html`. Design the **whole**
-  feature here — every surface and behavior Pete wants in scope — because this spec is the
-  scope contract PLAN and BUILD execute in full. A big feature is a big spec; don't trim
-  it to a slice.
-- **Fable builds the design HTML itself (Pete's call, 2026-07-18, reversing the
-  2026-07-16 sol split).** Design specs, mockups, and any artifact where visual taste
-  is the deliverable are **driver-authored inline** — direction, options, tradeoffs,
-  AND the page that shows them. No dispatch for design work. Template fills (go-card,
-  review-card) stay driver-inline as before.
-- **Shape the spec on the html-effectiveness patterns** — it's an explainer Pete decides
-  from, not a document he studies: `14-research-feature-explainer` is the body (TL;DR
-  first, collapsible depth, no wall of prose); when GATE 1 is a genuine *direction*
-  choice, present it as `02-exploration-visual-designs` — 2–3 **live-rendered**
-  directions side-by-side with one-line tradeoffs, so Pete picks by looking, not
-  reading; embedded mockups are live/interactive (`07`/`08-prototype`) — the spec *is*
-  the prototype; any flow or pipeline is a diagram (`13-flowchart-diagram`), never a
-  paragraph pretending to be one.
-- Write `gate:1` to `.ship-stage`, fire the gate notification (see "Gate signals"),
-  `open` the spec, and **end the turn with a `needs input:` line** naming the ship +
-  "design direction?". **HARD STOP — GATE 1.** Wait for approval.
+  whichever it uses) — e.g. `specs/designs/YYYY-MM-DD-<slug>.html` — covering the
+  **whole** feature; it's the scope contract PLAN and BUILD execute in full.
+  **The driver authors all design artifacts inline** — taste is the deliverable, never
+  dispatched.
+- **Spec shape:** `14-research-feature-explainer` body (TL;DR first, collapsible
+  depth); a genuine direction choice presents as `02-exploration-visual-designs` — 2–3
+  live-rendered directions side-by-side so Pete picks by looking; mockups are live
+  (`07`/`08-prototype`); flows are diagrams (`13-flowchart-diagram`).
+- Write `gate:1`, fire the gate notification, `open` the spec, end the turn with a
+  `needs input:` line ("design direction?"). **HARD STOP — GATE 1.**
 
-### 2 · PLAN — automatic  → marker: `plan`, then `gate:2`
+### 2 · PLAN — automatic  → marker: `plan`, then `gate:2` (or straight through)
 
-- Write `plan` to `.ship-stage`.
-- Invoke `superpowers:writing-plans` to produce ONE execution plan covering the **entire
-  spec** — every task to build the whole feature, however many that is. Do **not** slice
-  the feature into sequential ships/phases or defer specced surfaces; one plan, built in
-  one pass. Run `ponytail` as the *waste* critic, not a scope critic — it cuts
-  reinvention, over-abstraction, unneeded deps, and gold-plating, but never amputates
-  specced scope (the spec is the floor). Save its cut-list of dropped *waste* and the
-  markdown execution plan to the repo's docs home (e.g. `specs/plans/YYYY-MM-DD-<slug>.md`).
-- Render the HTML **go-card** from `reference/go-card.html` — the meta only (contract
-  below). Write `gate:2`, fire the gate notification, `open` the go-card, and **end the
-  turn with a `needs input:` line** naming the ship + "go?". **HARD STOP — GATE 2.**
-  (No effort/ultracode nudge — BUILD's writers are mostly codex now; run at whatever
-  effort the session already has.)
+- Write `plan`. Invoke `superpowers:writing-plans` for ONE execution plan covering the
+  **entire spec** — never sliced into phases. Run `ponytail` as the *waste* critic, not
+  a scope critic — it cuts reinvention and gold-plating, never specced scope. Save the
+  markdown plan to the docs home (e.g. `specs/plans/YYYY-MM-DD-<slug>.md`).
+- Render the HTML **go-card** from `reference/go-card.html` (contract below) and
+  `open` it.
+- **Gate or go:** if the card carries a genuine call (PM tradeoff, money path, your
+  judgment says he'd want to see it) — write `gate:2`, fire the gate notification, end
+  the turn with `needs input:` ("go?"). **HARD STOP.** Otherwise **auto-pass**: narrate
+  "gate 2 auto-passed — nothing needed you" and continue to BUILD.
 
 ### 3 · BUILD — automatic  → marker: `build:N:M` (N done of M tasks)
 
-- Write `build:0:<M>` to `.ship-stage`; bump N as each task completes. Build **all M
-  tasks** in one session — a big plan means a long build, and that is the job; don't stop
-  partway or hand back a half-built feature. Commit each task on the branch as it lands
-  (durable, resumable progress), but don't merge until the whole plan is built.
-- Invoke `superpowers:subagent-driven-development`, driven by the harness model (the driver).
-- Invoke `router` to dispatch each build task — currently all drafting goes to
-  GPT-5.6 **sol** via background **`codex exec`** (xhigh; always the sol
-  variant, never plain gpt-5.6) — Sonnet never, and the router skill owns the
-  engine dial (Pete's — read it there, don't restate it here). The driver owns
-  the brief, the diff review, the gates, and git. One writer per branch at a
-  time.
-- **Single-writer vs fan-out — pick by the diff, not by reflex** (matters most under
-  ultracode, where "always orchestrate" tempts you to parallelize the build). The default is
-  one writer on the branch: right for a small, interdependent, or design-coherent feature,
-  where parallel writers just race on the shared checkout for no gain. Fan out writers (each
-  in its own worktree, merged back) ONLY when tasks are genuinely independent *and* numerous
-  enough that isolation + merge beats serialized commits — a large migration, a broad
-  mechanical sweep. The high-value place to fan out is the **review**, regardless of build
-  size: independent reviewers per dimension + adversarial verification (see REVIEW). Don't
-  parallelize 5 small edits; do parallelize 5 verifiers.
-- Apply `ponytail` posture (shortest diff, reuse, no reinvention).
-- Run `superpowers:verification-before-completion` before claiming any task done — actually run it.
-- On a red test, `superpowers:systematic-debugging`.
-- **Before BUILD is done, walk the whole feature end-to-end yourself** — a quick *self-driven*
-  smoke-walk (the formal fresh-agent `verify` skill runs in REVIEW, not here — don't invoke it
-  twice): boot the app and drive its *real* user paths (the spec's happy path + key edge cases),
-  not just unit tests. Two smoke-walk preconditions that have each cost a red deploy: **if the
-  change touches a framework with its own production build** (`flue build`, `next build`,
-  wrangler/vite bundling), **run that build too** — tsc+vitest green ≠ deployable; and **if the
-  branch touched `convex/`, re-push it to the per-branch preview first**
-  (`npx convex deploy --preview-name <branch> -y`) — the preview holds stage-0 code and drifts
-  behind every Convex commit. *You* find the breakage, never Pete. Fix what breaks (loop with
-  `systematic-debugging`); only leave BUILD once the live flow actually works. The review card's
-  end-to-end promise ("it runs" — backed by REVIEW's verify pass) must stay true.
-- Raise a hand only for a genuine fork (PM-framed, with a rec). Pete can jump in from
-  FleetView anytime.
+- Write `build:0:<M>`; bump N per task. Build **all M tasks** in one session; commit
+  each task on the branch as it lands, merge only when the whole plan is built.
+- Invoke `superpowers:subagent-driven-development` (the driver drives) and `router` to
+  dispatch each task — drafting goes to codex per the router; sub-overhead work inline.
+  The driver owns the brief, the diff review, the gates, and git. One writer per branch
+  at a time.
+- **Single-writer vs fan-out — pick by the diff, not reflex.** Default one writer.
+  Fan out writers (own worktrees, merged back) only for genuinely independent AND
+  numerous tasks — a migration, a mechanical sweep. The high-value fan-out is the
+  **review**, regardless of build size: don't parallelize 5 small edits; do
+  parallelize 5 verifiers.
+- `ponytail` posture; `superpowers:verification-before-completion` before claiming any
+  task done — actually run it; `superpowers:systematic-debugging` on a red test.
+- **Before BUILD is done, smoke-walk the whole feature yourself** — boot the app and
+  drive the spec's real user paths (the formal `verify` runs in REVIEW; don't invoke it
+  twice). Two preconditions that have each cost a red deploy (incidents: Backends): a
+  framework with its own production build → **run that build too**; the branch touched
+  `convex/` → **re-push the preview** (`npx convex deploy --preview-name <branch> -y`).
+  *You* find the breakage, never Pete.
+- Raise a hand only for a genuine fork (PM-framed, with a rec).
 
 ### 4 · REVIEW / MERGE — automatic  → marker: `review`, then remove the file
 
-- Write `review` to `.ship-stage`.
-- **First: sync with main.** `git fetch origin`; if `origin/main` has commits the
-  branch lacks, absorb it *in the worktree* (rebase, or merge when rebase is
-  unsafe), re-run the repo gates, and only then dispatch the review — on
-  multi-session days main moves under every long ship, and a review against a
-  stale fork reviews apparent reversions of other ships' work (it has wasted
-  full review runs). Repeat right before the merge if main moved again during
-  REVIEW.
-- **Freeze the tree while a verifier is driving.** A live verify round holds a
-  read lock on the worktree: no merges, rebases, or edits until its verdict
-  lands — a mid-round `git merge` once left conflict markers in a hot-reloading
-  file, broke the dev server under the verifier, and wasted the whole Opus
-  round. Absorb upstream *before* dispatching the next round, never during.
-- **Correctness review runs on GPT-5.6 sol — codex's native review mode, launched
-  first so it works while the rest of REVIEW proceeds.** From the worktree,
-  background dispatch (router quick-reference rules apply — `< /dev/null`,
-  `-o` result file):
+- Write `review`. **Sync with main first**: `git fetch origin`; absorb upstream in the
+  worktree (rebase, or merge if unsafe), re-run the gates, then dispatch review — and
+  re-sync right before the merge if main moved again (incidents: Worktrees).
+- **Freeze the tree while a verifier is driving** — no merges, rebases, or edits until
+  its verdict lands (incidents: Worktrees). Absorb upstream *before* dispatching a
+  round, never during.
+- **Correctness review — codex's native review mode, launched first** so it works while
+  the rest of REVIEW proceeds. From the worktree, background dispatch:
   `codex exec review --base <lane-target-branch> -o <result-file> < /dev/null`
-  **No focus prompt** — codex rejects `[PROMPT]` alongside `--base` (or any
-  diff-source flag); review mode picks the diff and applies its own bug-hunt
-  rubric. Name the result file after the feature slug so the run is
-  attributable in `ps`. The over-build sweep (reinvented stdlib, speculative
-  abstraction, unneeded deps) is the driver's: run `ponytail-review` while
-  codex works. Review mode is
-  read-only by construction and computes the diff itself. Review inference is
-  heavy and codex is still the cheap engine — spend GPT-5.6 sol here, save Opus/Max
-  for judgment. Read the result file before the card; the **driver triages
-  every finding** — adversarial reviewers over-flag by design, so verify each
-  claimed bug against the code (receiving-code-review posture), fix what's
-  real, put judgment calls on the card. codex unavailable → fall back to
-  `/code-review` + `ponytail-review` on the driver.
-- **Design QA for visual features — a background codex dispatch drives and critiques**
-  with the GATE 1 spec as the bar: brief it to walk the built surfaces (its own
-  Playwright, screenshots to disk) and judge them against the spec on impeccable's
-  axes — hierarchy, spacing, alignment, theme fidelity, interaction states.
-  DISCOVER used impeccable to set the design bar; nobody but this
-  pass checks the *built* feature clears it (verify's taste notes are a smoke
-  test, not a design review). The driver triages its findings: real gaps get
-  fixed before the card, nits land on the card as "Verifier flagged / suggested"
-  for Pete to judge.
-- **Put it in front of Pete, running — every time.** For any visual/interactive feature
-  (the default on this web stack), **boot the worktree's own dev server yourself** (its dev
-  script — e.g. `next dev` — in the background) and `open http://localhost:<port>` (usually
-  `:3000`) so the *live local app* is on his screen the instant he's asked to review. He
-  walks through it on the worktree. **Never deploy to let him review, and never tell him to
-  "go look at the live site"** — deploy is downstream of merge; the worktree's localhost is
-  the review surface. (Non-UI change — CLI/library — show the demo/test output instead.)
-- **Prove it actually works — invoke `verify` before the card.** With the app running,
-  invoke the `verify` skill against the worktree's localhost. A fresh read-only **codex
-  (GPT-5.6 sol)** verifier drives the feature, screenshots the beats, and returns `works | broken | unverifiable` +
-  taste notes; verify loops-to-fix (cap ~3). **`broken` after the cap, or `unverifiable`, →
-  do NOT proceed to merge: end the turn with a `needs input:` line ("review: <feature> —
-  couldn't prove it works: <reason>") and hand Pete the verdict + evidence.** Only a `works`
-  verdict (with its screenshot storyboard + any taste notes) flows into the card below; if verify
-  crystallized an e2e spec for a core journey, name that path in "Already checked for you".
-- **Render a review card** from `reference/review-card.html` (contract below), write it to
-  the repo's docs home (e.g. `specs/plans/review-<slug>.html`), and `open` it. Point it at
-  the running localhost ("walk through it — it's already open"). **Never tell Pete to "go
+  No focus prompt (incidents: codex); name the result file after the slug. Meanwhile
+  the driver runs `ponytail-review` (the over-build sweep). Read the result file; the
+  **driver triages every finding** — adversarial reviewers over-flag by design — fixes
+  what's real, puts judgment calls on the card. codex unavailable → `/code-review` +
+  `ponytail-review` on the driver.
+- **Design QA for visual features** — a background codex dispatch walks the built
+  surfaces and judges them against the GATE 1 spec on impeccable's axes (hierarchy,
+  spacing, theme fidelity, interaction states). Driver triages: real gaps fixed before
+  the card, nits land on the card for Pete.
+- **Put it in front of Pete, running.** For any visual/interactive feature, boot the
+  worktree's dev server in the background and `open http://localhost:<port>` so the
+  live local app is on his screen. **Never deploy to let him review; never tell him to
+  "go look at the live site"** — the worktree's localhost is the review surface.
+  (Non-UI change → show the demo/test output instead.)
+- **Prove it works — invoke `verify` before the card.** A fresh read-only codex
+  verifier drives the feature and returns `works | broken | unverifiable` + a
+  screenshot storyboard; verify loops-to-fix (cap ~3). **`broken` after the cap, or
+  `unverifiable` → do NOT merge**: end the turn with `needs input:` ("review: <feature>
+  — couldn't prove it works: <reason>") and hand Pete the verdict + evidence.
+- **Render the review card** from `reference/review-card.html` (contract below) to the
+  docs home and `open` it, pointed at the running localhost. **Never tell Pete to "go
   read the PR"** — the review comes to him, running and labeled.
-- **The merge gate always holds for GATED ships.** Present the running app + the
-  review card, end with a `needs input:` line ("review: <feature> — merge?"), and **wait.
-  Never merge a gated UI Pete hasn't seen run** — a standing "go" authorizes the build, not
-  the merge of an unseen feature. (EXPRESS / SELF-DIRECTED ships merge autonomously — their
-  bar is green gates + verify's `works`, per Sizing — and a tiny, non-visual, watched change
-  may `wt merge` directly.)
-- **When Pete asks for changes at the card, apply `superpowers:receiving-code-review`** —
-  verify the ask against the code before implementing (his feedback is product-true but
-  may be technically underspecified), do the work, then loop the changed flow back
-  through `verify` before re-presenting. Never blind-implement and re-card.
-- On "merge", land it and **let worktrunk own teardown — a leftover worktree is a bug**:
-  - **Tiny & watched →** `wt merge` (runs the repo's `wt.toml` pre-merge gate, squashes,
-    ff's main, removes the worktree — worktrunk merges *from* the worktree safely), then
-    `ExitWorktree({action:"keep"})` in Claude Code, or point subsequent Codex tool calls at
-    the main checkout (wt already deleted the dir).
-  - **Substantial (PR path) → the merge must run from the MAIN CHECKOUT, never from inside the
-    worktree.** `gh pr merge` checks out the base branch locally after merging; run from inside
-    the worktree it dies with `fatal: 'main' is already used by worktree …` — the PR merges on
-    GitHub but the local step fails, so teardown never runs and Pete is stranded in an orphan
-    worktree (this has bitten real runs). So **tear down FIRST, then merge — after a merge
-    pre-flight**, because tearing down a worktree whose PR then conflicts strands the ship
-    with no worktree and no merge (that recovery is all manual):
-    0. Pre-flight *from the worktree*: `git fetch origin` — if main moved, absorb + re-gate
-       (the REVIEW sync step) and push; then confirm `gh pr view <#> --json mergeable` says
-       `MERGEABLE`. Never tear down a worktree whose PR can't merge.
-    1. Return to the main checkout: Claude Code `ExitWorktree({action:"keep"})`; Codex sets
-       subsequent tool calls to the main checkout path.
-    2. `wt remove feature/<slug> -f` — remove the local worktree now (frees the branch so
-       `--delete-branch` can delete it; you're about to merge it anyway).
-    3. `gh pr merge <#> --squash --delete-branch` — now from the main checkout: merges + deletes
-       the *remote* branch, no checkout conflict.
-    4. `git pull --ff-only` so local main matches (+ `git branch -D feature/<slug>` if the squash
-       left an "unmerged" local branch behind). Nothing left on disk. **If the main checkout is
-       dirty with another session's uncommitted work** (`git status --porcelain`), skip the local
-       ff — leave their work untouched — and run any deploy step from a throwaway worktree pinned
-       to `origin/main`, never from the dirty checkout (deploying it would ship their unfinished
-       work and miss your merge).
-  - **Session living in a pre-existing worktree ship didn't create** (e.g. Zero's sibling-worktree
-    convention): don't tear down what isn't yours — the session and its dev server live there.
-    Instead: `gh pr merge <#> --squash -R <owner/repo>` *without* `--delete-branch`,
-    `git push origin --delete <branch>` to drop the remote branch, ff the main checkout, and
-    leave the worktree + local branch in place (Pete's, not ship's). The zero-worktrees
-    assertion below scopes to worktrees ship itself created.
-  - Then `rm .ship-stage`, **stop the review dev server you booted** (its worktree is being
-    removed), and **deprovision the per-branch preview backend if Stage 0 spun one up** — close
-    the resource you opened, or skip if the repo's previews auto-expire (don't leave orphaned
-    backends piling up). **Verify with `git worktree list` — zero ship worktrees must remain. A
-    leftover worktree means the teardown failed (usually the merge ran inside the worktree) —
-    recover it before you declare done.**
-- **Ship deploys to the integration lane, never to production.** After the merge, push merged
-  main to the repo's shared *dev/integration* lane if it has one — run its dev-deploy step **from
-  the main checkout** (homezero: `scripts/deploy-dev.sh`, the single serialized writer for the
-  shared dev plane; never run it from a worktree — that's the clobbering bug again), then hand
-  back that lane's URL (homezero: `dev.homezero.md`). If the repo just auto-deploys on merge via
-  CI, say so and hand back the URL once it's up; if it has no deploy step, confirm merged. Never
-  make Pete run a deploy himself. Three deploy-watch rules, each from a real incident:
-  - **Watch the deploy to conclusion — a red deploy is unfinished work**, on every lane
-    including EXPRESS and batch runs (a batch once merged 18 green PRs over a dev lane that
-    had been red for an hour). Red → diagnose, fix-forward on a new express branch,
-    re-verify. Batch fleets: one watcher for the final merge wave is enough.
-  - **Watch the run for YOUR commit** — `gh run list --commit <sha>` — not "the latest run":
-    a following merge's push can cancel yours via workflow concurrency, and the superseding
-    run's green reads as yours while dev is actually mid-deploy. Cheap artifact check before
-    handing back the URL: fetch the lane's HTML shell and confirm a marker the diff introduced.
-  - **A red *shared*-lane deploy you didn't cause is a shared resource** — before authoring a
-    fix, check for an existing fix PR (`gh pr list --search`) and open a **draft PR first as
-    the claim**; two sessions once raced identical fixes and one ship was thrown away.
-- **Promotion to production is NOT ship's job — shipping ends at the integration lane.** On the
-  three-lane model this assumes (a separate prod promote), "merged" means live on *dev*, not live
-  for users — so never deploy or promote to prod / `www`, never add a promote gate or offer to
-  promote (homezero: `scripts/promote-to-prod.sh` is a separate, human-gated ritual Pete runs on
-  his own cadence — deliberately outside the pipeline). (Only where merge auto-deploys straight to
-  prod is a merge itself the user-facing release — the review-card "Merge?" line covers that case.)
-  Hand back the dev URL and stop there.
-- Run the RETRO below, then **end with a `result:` line**: what shipped, one sentence — and if
-  RETRO filed a note, name it (`… · ship-retro #N filed`). If the run left backlog candidates on
-  the review card, name the count too (`… · 2 backlog candidates`) so Pete knows to approve them.
+- **The merge gate always holds for GATED ships**: present the running app + card, end
+  with `needs input:` ("review: <feature> — merge?"), and wait. **Never merge a gated
+  UI Pete hasn't seen run** — a standing "go" authorizes the build, not the merge of an
+  unseen feature. EXPRESS / SELF-DIRECTED merge autonomously on green gates + `works`.
+- Changes Pete asks for at the card go through `superpowers:receiving-code-review` —
+  verify the ask against the code, do the work, loop the changed flow back through
+  `verify` before re-presenting.
+- **Merge — the PR path, from the MAIN CHECKOUT, teardown first** (incidents:
+  Worktrees — both orderings that deviate have stranded ships):
+  0. Pre-flight *from the worktree*: `git fetch origin`; if main moved, absorb +
+     re-gate + push; confirm `gh pr view <#> --json mergeable` says `MERGEABLE`.
+  1. Return to the main checkout (`ExitWorktree({action:"keep"})`; Codex: absolute
+     paths).
+  2. `wt remove feature/<slug> -f` — frees the branch for `--delete-branch`.
+  3. `gh pr merge <#> --squash --delete-branch` — from the main checkout.
+  4. `git pull --ff-only` (+ `git branch -D feature/<slug>` if a local branch
+     lingers). **Dirty main checkout** (another session's work) → skip the local ff
+     and run any deploy from a throwaway worktree pinned to `origin/main`.
+  - Session living in a worktree ship didn't create (Zero's sibling convention):
+    don't tear down what isn't yours — merge with `-R <owner/repo>` sans
+    `--delete-branch`, `git push origin --delete <branch>`, leave the worktree.
+  - No GitHub remote → `wt merge` (squashes, ff's main, removes the worktree) is the
+    fallback.
+  - Then `rm .ship-stage`, **stop the review dev server**, **deprovision the preview
+    backend** stage 0 spun up (or skip if previews auto-expire). Verify with
+    `git worktree list` — zero ship-created worktrees must remain; a leftover means
+    teardown failed (usually a merge run inside the worktree) — recover before
+    declaring done.
+- **Deploy to the integration lane, never production.** Push merged main to the repo's
+  dev lane per its ship contract — its dev-deploy step runs **from the main checkout**
+  (shared-plane writer; incidents: Backends) — and hand back the lane's URL. CI
+  auto-deploy → say so and hand the URL once up. Never make Pete run a deploy. Watch
+  rules (each from a real incident — incidents: Backends): **watch the deploy to
+  conclusion** (red = unfinished work, fix-forward on a new express branch); **watch
+  the run for YOUR commit**, not "latest," and artifact-check the lane; **a red shared
+  lane you didn't cause is a shared resource** — check for an existing fix PR, claim
+  with a draft PR first.
+- **Promotion to production is NOT ship's job.** "Merged" means live on *dev*. Never
+  promote to prod / `www`, never offer to (the repo's promote script is Pete's own
+  human-gated ritual). Only where merge auto-deploys straight to prod is the merge
+  itself the release — treat the review card's "Merge?" accordingly.
+- Run RETRO, then **end with a `result:` line**: what shipped, one sentence — plus
+  `· ship-retro #N filed` and/or `· K backlog candidates` when applicable.
 
-### 5 · RETRO — autonomous; only if the run taught us something  → no marker
+### 5 · RETRO — autonomous; only if the run taught something  → no marker
 
-Ship improves itself from its own runs — but the *running* agent never edits the skill. You're
-shipping someone's feature, not doing skill surgery, and one run is too narrow a view to write a
-*general* fix. So do a fast autonomous retro and **drop a note for the ship maintainer** — no
-gate, no PR, no waiting on Pete.
-
-If this run surfaced a real gap — Pete corrected the pipeline, a stage misfired, a step was
-missing — file it as a GitHub issue on the skill's own repo (for this skill, `peteknowsai/ship`),
-labeled `ship-retro`:
+The *running* agent never edits the skill — you're shipping a feature, not doing skill
+surgery, and one run is too narrow for a general fix. If this run surfaced a real gap
+(Pete corrected the pipeline, a stage misfired), file it for the maintainer:
 
 ```
 gh issue create -R peteknowsai/ship --label ship-retro --title "retro: <one-line gap>" \
-  --body "<what happened · the gap · a suggested fix (which stage, roughly what to change) · the repo/feature it came from>"
+  --body "<what happened · the gap · a suggested fix · the repo/feature it came from>"
 ```
 
-Include the **suggested fix** so the maintainer has a concrete starting point — but you do NOT
-open a PR or touch the skill. The ship-maintainer agent monitors the `ship-retro` label, batches
-notes across runs into one *general* skill change, and reviews that PR with Pete.
-
-- **Most runs teach nothing — skip silently.** Never invent a lesson; a clean run files no note.
-  One real note beats five padded ones.
-- Don't gate `result:` on this — file the note (or don't) and finish the run.
-
-## The review card (REVIEW artifact)
-
-Render `reference/review-card.html` filled with the meta only — PM-framed, one screen.
-It's a `17-pr-writeup` for a PM: what changed and why with visual before/after evidence,
-never a file tour. Pete reviews *this*, not the diff:
-
-- **What you got** — plain-English bullets of what now works (what it *does*, not a file list).
-- **Proof it works** — the verifier's captioned screenshot **storyboard** (start → action →
-  success) with the `works` verdict on top. This replaces a static mockup: it's evidence the
-  running feature does what was intended, organized for a glance. It's also still **running for
-  him at localhost** (you booted it). (Non-visual change — show the demo/test output instead.)
-- **Already checked for you** — gates/tests green, **the flow driven end-to-end by a fresh
-  agent (it runs)**, plus any **e2e spec verify committed** for a core journey (name it — that
-  path is a standing test now); what was NOT touched (schema / money / public surfaces). Set his
-  risk expectation.
-- **Verifier flagged / suggested** — the verifier's taste notes ("looked off / couldn't
-  confirm"), if any. These are *reports, not work* — Pete decides: fix now / backlog / ignore.
-- **Only you can confirm** — the 1–2 things that need his eye; walk through them on the open
-  localhost.
-- **Also worth building — didn't make this round** — the run's *backlog candidates*: build-worthy
-  things you deliberately left out of this round (see the collection rule below). Each one: what
-  it is, one line on *why* it was deferred, and a proposed board destination (Backlog default;
-  Icebox for the clearly-speculative). **Most rounds have none** — omit the card entirely when
-  the list is empty; never pad it. This is **non-blocking**: the card lists them and the
-  `result:` line names the count — nothing stops for them.
-- **Merge?** — the PR link is there for the curious, but he shouldn't need it. Merge lands the
-  feature on the **integration lane** (dev where the repo has one, else just main) — not on
-  users, so it's a reversible, low-stakes yes once he's seen it run. (Only where merge
-  auto-deploys straight to prod is it the point of no return — treat it that way there.)
-
-### The board is the run's record (board-backed repos)
-
-Where the repo has a backlog-board skill (homezero → the `linear` skill, which holds all the
-mutations and recipes), the ticket mirrors the run — Pete follows a ship from his phone by
-opening the card. **The board is a mirror, never a gate**: an API hiccup gets one line of
-narration and the pipeline rolls on; no stage ever waits on Linear.
-
-- **Run start** — move the matching card to In Progress. A GATED ship with no card gets one
-  created (title = the feature, description = Pete's ask in his words). EXPRESS runs skip the
-  board entirely unless a card already exists for the work.
-- **GATE 1, design approved** — publish the spec HTML to the repo's public specs host
-  (homezero: `specs.homezero.md` — the linear skill's R2 recipe, ~2s, **never the dev
-  deploy**), then comment on the issue: 3-line design summary + the spec link. **Ticket links
-  are always public URLs** — never localhost, never a file path.
-- **PLAN** — mirror the plan's punch list into the issue description as markdown checkboxes;
-  check items off as build tasks land. The ticket is the punch list; the HTML is the depth.
-- **Merge** — move the card to **For Review** and make **the ticket itself the review ask** —
-  Pete does his final pass from the ticket on his phone, no HTML required. Append a
-  `## For your review` section to the description: the dev-lane URL to test at, then
-  **checkboxes for exactly what needs his eye** (the "only you can confirm" items + any
-  verifier flags — the same content the review card carries), and a 1–2 line *what shipped*.
-  Close with a comment carrying the `result:` line + verify verdict. Publish + link the
-  review-card HTML **only when there's more than the ticket can hold** (a screenshot
-  storyboard, before/afters) — depth behind a link, never the primary surface. Never move to
-  Done — **Done is Pete's drag**: he tests on dev, ticks the boxes, and moves the card
-  himself; ship's pipeline ends at For Review on the board just as it ends at the dev lane
-  in the repo. (GATED ships still present the review card at the merge gate as always — this
-  is about what lands on the ticket after the merge.)
-- **Bigger than this round** — when the design reveals real phases beyond this ship, create a
-  board **project**: this round's issue goes in it, the later phases are filed as issues in the
-  same project, and the spec link lives on the project description. Next round picks up inside
-  the project instead of re-discovering the shape.
-
-### Backlog candidates — collect deferrals, surface them, file on approval
-
-A ship run keeps throwing off *build-worthy ideas that aren't this round's job* — a surface you
-scoped out in DISCOVER ("not this round"), an over-build the `ponytail` review said to cut but
-that's a real feature later, an adjacent thing the verifier or the build turned up. Today they
-evaporate. Don't let them.
-
-- **Collect as you go — no scratch file, you're one continuous run.** As the driver you see every
-  deferral source (DISCOVER scope cuts, the ponytail/verifier reports, ideas noticed mid-build).
-  Keep a running list of the ones you'd *actually build*, each with a one-line *why-deferred*.
-  Same bar as RETRO: **most runs defer nothing worth keeping** — a genuine candidate, not every
-  passing thought. **A candidate is a thing OUTSIDE this spec's scope** — an adjacent feature, a
-  nice-to-have the work exposed. It is *never* a specced surface you chose not to build: the scope
-  law holds (build the whole spec, never slice it into "Ship 1 of N"), and this section is not a
-  loophole around it. New ideas the run surfaced, yes; specced work deferred, never.
-- **Surface in the review card** — the "Also worth building" card (above), one `.cand` per item
-  with a proposed destination: **Backlog** by default ("things we intend to build"), **Icebox**
-  only for the clearly-speculative. Empty list → omit the card.
-- **File on approval — non-blocking.** The `result:` line names the count ("· 2 backlog
-  candidates"). When Pete says *file them* (or names which), file each through the repo's backlog
-  board and reply with the links — only where the repo *has* one: a configured backlog skill
-  (homezero → the `linear` skill, HOM board; `stateId` Backlog default, Icebox for speculative;
-  description = the idea + "deferred from ship run on `<feature>`"). Candidates that are
-  **phases of one larger design** go into that design's board *project* (see the board-record
-  section) instead of loose backlog cards. **No board for this repo → the card and the
-  `result:` line are the record; don't invent a tracker.** Never gate the merge or the
-  `result:` line on this — approval is always async.
-
-## Running under Codex Desktop
-
-Same pipeline, same gates, same artifacts — these mechanical swaps apply **only when
-the driver is a Codex Desktop session** (they override the Claude Code specifics above):
-
-- **Worktrees: Codex owns birth and cleanup — never run `wt` against a Codex-managed
-  worktree** (no `wt switch --create`, no `wt merge`, no `wt remove`, no nesting a wt
-  worktree inside one). Preferred start: the thread already in **Worktree mode** off
-  `main` — Codex creates the worktree (usually detached HEAD) under
-  `$CODEX_HOME/worktrees`. Sanity-check where you are (`git rev-parse --show-toplevel`,
-  `git branch --show-current`); if detached, make the branch real before the first
-  commit: `git switch -c feature/<slug>`. If the thread is **Local on `main`**, do NOT
-  edit — stop with `needs input: click Fork into new worktree for this ship`. (**Fork
-  into local** is only for when Pete explicitly wants the work in his foreground
-  checkout.)
-- **Artifacts open in Codex's in-app Browser**, not via macOS `open`: serve the
-  artifact's directory on localhost and navigate the in-app Browser there (raw
-  `file://` URLs are unreliable in Codex); a running app's localhost URL opens
-  directly. Fall back to `open`/Chrome only if the in-app Browser is unavailable or
-  Pete asks.
-- **Merge is the PR path only**: push the branch, open the PR, merge via Codex's Git
-  UI or `gh pr merge <#> --squash --delete-branch` — never from inside the branch's
-  own worktree. Then `rm .ship-stage`, stop the review dev server, deprovision the
-  preview backend — but **leave worktree cleanup to Codex** (archive the thread).
-- **No status line, no FleetView** — narration carries the load alone. Every status /
-  `needs input:` / `result:` line ends with the `branch <branch> · worktree <path>`
-  breadcrumb (see the narration contract), and `hooks/gate-notify.sh` isn't auto-wired
-  — run it manually at gates if it's present.
-
-## Gate signals — how a parked ship reaches Pete
-
-When you hit a gate, three things fire so Pete notices whether he's watching or away:
-
-1. **Status line** — the `gate:N` marker makes the line show `✋ <slug> — design?/go?` in
-   bold amber. His in-session and in-dashboard glance.
-2. **FleetView bucket** — end the turn with a line starting `needs input:` → the
-   dashboard row jumps to the **awaiting input** group. (See the narration contract.)
-3. **Desktop notification** — the gate Stop-hook fires a Ghostty notification
-   (`<slug> → GATE N`) so an away-from-keyboard Pete gets a tap on the shoulder. Gates
-   are rare, so this is never noisy.
-
-## FleetView narration contract
-
-The dashboard can't be styled, but it reflects the session. Make it a ship board:
-
-- **Name** the session `ship:<slug>` at spawn (Pete types it, or v2 dockmaster passes
-  `--name`). A running session can't rename itself reliably.
-- **End every turn with a clean one-line status** (`🔨 build 4/5 · <slug>`,
-  `📐 planning · <slug>`). The Haiku summarizer mirrors your latest line into the row —
-  give it status-of-work, not an echo of the last tool call.
-- **At a gate, the closing line starts `needs input:`** → row moves to *awaiting input*.
-  **At merge, it starts `result:`** → row moves to *completed*. Mid-work narration keeps
-  it in *working*.
-- **End `needs input:` and `result:` lines with `branch <branch> · worktree <path>`**
-  (`detached@<short-sha>` until a branch exists). Pete must always know which checkout
-  he's looking at — this is what catches the cross-repo case where no status line is
-  watching, and under Codex Desktop it's the only location signal there is.
+**Most runs teach nothing — skip silently.** Never invent a lesson. Don't gate
+`result:` on this.
 
 ## The go-card contract (GATE 2 artifact)
 
-Render `reference/go-card.html` filled with the meta only — one screen, nothing more
-(the template is a `16-implementation-plan` boiled down to its decision surface —
-scope, calls, risk — everything else stays in the machine-facing plan):
+Render `reference/go-card.html` filled with the meta only — one screen (a
+`16-implementation-plan` boiled down to its decision surface):
 
 - **What gets built** — one line of scope.
 - **Ponytail's cut-list** — what was dropped, and why.
-- **Pete's 1–3 calls** — each a PM tradeoff *with your recommendation*. (Often zero —
-  then say "nothing needs you" and it's a pure confirm.)
+- **Pete's 1–3 calls** — each a PM tradeoff *with your recommendation*. Zero calls →
+  the gate auto-passes (see Two principles); the card is still rendered for the record.
 - **Risk** — one line.
-- **Mockup thumbnail** — if the feature is visual, pulled from the design spec.
-- **Go** — one line: BUILD starts the moment Pete says go.
+- **Mockup thumbnail** — if visual, from the design spec.
+- **Go** — one line.
 
 It is the *only* thing Pete reads before a build starts. Never make him read the plan.
 
-## What this skill deliberately does NOT do
+## The review card (REVIEW artifact)
 
-No arbitrary phasing — ship plans and builds the whole spec in one pass, never slicing a
-specced feature into "Ship 1 of N" and stopping (phasing is Pete's to request, not ship's
-to impose). No `executing-plans` (checkpoint-heavy — the opposite of hands-off). No strict
-TDD by default (tests are a build deliverable; the pre-merge test gate is the backstop;
-reserve test-first — `superpowers:test-driven-development` — for money/auth paths). No manual git worktree management — `wt` owns the
-worktree birth-to-death in Claude Code, Codex Desktop owns its own managed worktrees
-(never `wt` inside one). No promoting to production — ship ends at the integration lane (dev);
-promotion to prod / `www` is a separate, human-gated ritual Pete runs, never ship's to deploy,
-gate, or offer.
+Render `reference/review-card.html` filled with the meta only — PM-framed, one screen; a
+`17-pr-writeup` for a PM, never a file tour. Pete reviews *this*, not the diff:
+
+- **What you got** — plain-English bullets of what now works.
+- **Proof it works** — the verifier's captioned screenshot storyboard (start → action →
+  success) with the `works` verdict on top; the app is also still running for him at
+  localhost. (Non-visual → demo/test output.)
+- **Already checked for you** — gates green, the flow driven end-to-end by a fresh
+  agent, any committed e2e spec (name it); what was NOT touched (schema / money /
+  public surfaces).
+- **Verifier flagged / suggested** — taste notes, if any. Reports, not work — Pete
+  decides: fix now / backlog / ignore.
+- **Only you can confirm** — the 1–2 things that need his eye, on the open localhost.
+- **Also worth building — didn't make this round** — the run's backlog candidates (see
+  below). Most rounds have none — omit the section entirely; never pad it.
+- **Merge?** — the PR link is there for the curious, but he shouldn't need it. Merge
+  lands on the integration lane — reversible, low-stakes. (Only where merge
+  auto-deploys to prod is it the point of no return — say so there.)
+
+## The board is the run's record (board-backed repos)
+
+Where the repo has a backlog-board skill (e.g. homezero → the `linear` skill, which
+holds the mutations and recipes), the ticket mirrors the run. **The board is a mirror,
+never a gate** — an API hiccup gets one line of narration and the pipeline rolls on.
+
+- **Run start** — card to In Progress (GATED ships with no card get one created).
+  EXPRESS skips the board unless a card already exists.
+- **GATE 1 approved** — publish the spec HTML to the repo's public specs host (never
+  the dev deploy), comment the 3-line summary + link. **Ticket links are always public
+  URLs** — never localhost or file paths.
+- **PLAN** — mirror the punch list into the description as checkboxes; tick as tasks
+  land.
+- **Merge** — card to **For Review**; the ticket becomes the review ask: a
+  `## For your review` section with the dev-lane URL, checkboxes for what needs his
+  eye, and a 1–2 line what-shipped; close with a comment carrying the `result:` line +
+  verdict. Link the review-card HTML only when the ticket can't hold the depth.
+  **Never move to Done — Done is Pete's drag.**
+- **Bigger than this round** — real phases beyond this ship become a board *project*:
+  this issue joins it, later phases are filed inside it, the spec link lives on the
+  project.
+
+## Backlog candidates — collect deferrals, file on approval
+
+A run throws off build-worthy ideas that aren't this round's job. Keep a running list
+(no scratch file — you're one continuous run) of the ones you'd *actually build*, each
+with a one-line why-deferred. **A candidate is a thing OUTSIDE the spec's scope** —
+never a specced surface you chose not to build; this is not a loophole around the scope
+law. Surface them on the review card; the `result:` line names the count. When Pete
+says *file them*, file through the repo's board skill and reply with links (Backlog
+default, Icebox for the speculative; phases of one design go into its board project).
+No board → the card is the record; don't invent a tracker. Never gate the merge on
+this — approval is always async.
+
+## Running under Codex Desktop
+
+Same pipeline, gates, and artifacts — these swaps apply only when the driver is a Codex
+Desktop session:
+
+- **Worktrees: Codex owns birth and cleanup — never run `wt` against a Codex-managed
+  worktree.** Preferred start: the thread already in Worktree mode off `main`. Sanity-
+  check location (`git rev-parse --show-toplevel`); if detached HEAD, `git switch -c
+  feature/<slug>` before the first commit. Thread is Local on `main` → do NOT edit;
+  stop with `needs input: click Fork into new worktree for this ship`.
+- **Artifacts open in Codex's in-app Browser** — serve the artifact's directory on
+  localhost and navigate there (`file://` is unreliable); a running app's URL opens
+  directly.
+- **Merge is the PR path only**, never from inside the branch's worktree; then
+  `rm .ship-stage`, stop the dev server, deprovision the preview — but **leave worktree
+  cleanup to Codex** (archive the thread).
+- **No status line, no FleetView** — narration carries the load alone; every status /
+  `needs input:` / `result:` line ends with the breadcrumb, and `hooks/gate-notify.sh`
+  runs manually at gates if present.
+
+## Gate signals — how a parked ship reaches Pete
+
+At a gate, three things fire so Pete notices whether he's watching or away:
+
+1. **Status line** — the `gate:N` marker shows `✋ <slug> — design?/go?` in bold amber.
+2. **FleetView bucket** — the turn ends with a `needs input:` line → the row jumps to
+   *awaiting input*.
+3. **Desktop notification** — the gate Stop-hook fires a Ghostty notification
+   (`<slug> → GATE N`). Gates are rare, so this is never noisy.
+
+## FleetView narration contract
+
+The dashboard reflects the session — make it a ship board:
+
+- **Name** the session `ship:<slug>` at spawn (Pete types it, or dockmaster passes
+  `--name`). A running session can't rename itself reliably.
+- **End every turn with a clean one-line status** (`🔨 build 4/5 · <slug>`,
+  `📐 planning · <slug>`) — status-of-work, not an echo of the last tool call.
+- **At a gate, the closing line starts `needs input:`** → *awaiting input*. **At merge,
+  it starts `result:`** → *completed*. Mid-work narration keeps it in *working*.
+- **End `needs input:` and `result:` lines with `branch <branch> · worktree <path>`**
+  (`detached@<short-sha>` until a branch exists) — Pete must always know which checkout
+  he's looking at; it's what catches the cross-repo case, and under Codex Desktop it's
+  the only location signal there is.
+
+## What this skill deliberately does NOT do — including two standing skill overrides
+
+**This pipeline overrides the superpowers defaults on its autonomous lanes** (a
+deliberate ruling, not an oversight): `superpowers:brainstorming` runs only in DISCOVER
+(GATED / `design`) — EXPRESS and SELF-DIRECTED skip it; and there is **no strict TDD by
+default** — tests are a build deliverable, the pre-merge gate is the backstop, and
+test-first (`superpowers:test-driven-development`) is reserved for money paths.
+
+Also not ship's job: arbitrary phasing (the scope law); `executing-plans`
+(checkpoint-heavy — the opposite of hands-off); manual git worktree management (`wt`
+owns birth-to-death in Claude Code; Codex Desktop owns its own); promoting to
+production (ship ends at the integration lane — promotion is Pete's separate,
+human-gated ritual, never ship's to run, gate, or offer).

--- a/plugins/ship/skills/pipeline/reference/incidents.md
+++ b/plugins/ship/skills/pipeline/reference/incidents.md
@@ -1,0 +1,84 @@
+# Learned environment facts — from real failed runs
+
+Facts about how this environment actually behaves, each learned from a real incident.
+Consult the relevant section before merges, teardowns, deploys, or debugging a dispatch.
+These are facts, not process — the process lives in SKILL.md.
+
+## Worktrees & git
+
+- **Cross-repo `EnterWorktree` silently doesn't take.** It only adopts worktrees of the
+  session's *primary* repo. Against any other repo the cwd never moves and the status
+  line stays blind — the worktree and `.ship-stage` are real but invisible. Work by
+  absolute path and narrate the fork (see the narration contract).
+- **`gh pr merge` run from inside the worktree fails** with `fatal: 'main' is already
+  used by worktree …` — the PR merges on GitHub but local teardown never runs, stranding
+  an orphan worktree. Merge from the main checkout, always.
+- **Tearing down a worktree before confirming its PR is `MERGEABLE`** strands the ship
+  with no worktree and no merge — that recovery is all manual. Pre-flight first.
+- **Squash merges from the GitHub UI don't satisfy `git branch --merged`** and don't
+  delete the local branch. To prove a worktree landed, check
+  `gh pr list --state merged --head <branch> --json number,headRefOid` against the
+  worktree's HEAD.
+- **A dirty main checkout may hold another session's uncommitted work.** Never ff or
+  deploy from it — deploying would ship their unfinished work and miss your merge. Use a
+  throwaway worktree pinned to `origin/main` for the deploy step.
+- **A pre-existing sibling worktree (Zero's convention) is not ship's to tear down** —
+  the session and its dev server live there. Merge with `-R <owner/repo>` without
+  `--delete-branch`, delete the remote branch explicitly, leave the worktree.
+- **Mid-round `git merge` while a verifier is driving** left conflict markers in a
+  hot-reloading file, broke the dev server under the verifier, and wasted the round.
+  Freeze the tree while any verify round is live.
+- **Review against a stale fork reviews apparent reversions** of other ships' work —
+  full review runs have been wasted. Sync with origin/main before dispatching review,
+  and again before the merge.
+
+## Backends & deploys
+
+- **A worktree building against a shared backend clobbers it** — pushing the branch's
+  schema reconciles the shared plane to this branch and drops indexes other branches
+  added. Per-branch preview backends exist for this; the shared dev deploy runs only
+  from the main checkout.
+- **Convex previews hold stage-0 code and drift behind every `convex/` commit.**
+  Re-push before the smoke-walk: `npx convex deploy --preview-name <branch> -y`.
+- **tsc + vitest green ≠ deployable.** Frameworks with their own production build
+  (`next build`, `flue build`, wrangler/vite bundling) have failed on deploy after green
+  tests. Run the production build in the smoke-walk.
+- **A batch once merged 18 green PRs onto a dev lane that had been red for an hour.**
+  A red deploy is unfinished work on every lane — watch to conclusion.
+- **Workflow concurrency can cancel your deploy run**; the superseding run's green reads
+  as yours while the lane is mid-deploy. Watch the run for YOUR commit
+  (`gh run list --commit <sha>`), and artifact-check the lane before handing back a URL.
+- **Two sessions once raced identical fixes to a red shared lane** and one ship was
+  thrown away. Check for an existing fix PR first; open a draft PR as the claim.
+
+## Design & review
+
+- **A plan once specced a fresh `events` table the repo already had** — three tasks got
+  rewritten mid-build. The reuse audit (grep the whole repo for every core noun,
+  data layer included) exists because of this.
+- **A hypothesized bug cause once produced a fix that would have made an agent fabricate
+  data** — the real cause was a 500ing dependency. Bug-shaped asks get an empirical
+  root-cause check before the spec commits to a cause.
+- **A run once designed against a repo's old cream mockups while the live product had
+  moved to a dark terminal UI** — caught at GATE 1, whole spec redone. The running app is
+  the design source of truth, never in-repo mockups.
+
+## codex dispatch
+
+(The router skill carries the operational rules; these are the underlying incidents.)
+
+- **`codex exec` with stdin held open hangs at startup forever** — no session file, no
+  error. It once ate a night of dispatches and got misblamed on fast mode. `< /dev/null`
+  is mandatory.
+- **Runs killed at a 2-minute timeout got mislogged as failures** — they were healthy
+  xhigh runs that hadn't written a file yet. Liveness tell: the `~/.codex/sessions`
+  rollout file appears within seconds; patience (15–30 min) applies only after it exists.
+- **`codex exec resume --last` picks whichever run finished most recently anywhere on
+  the machine** — with concurrent sessions, that's usually not your task. Resume by
+  session id.
+- **`codex exec review` errors when a prompt is combined with `--base`** (or any
+  diff-source flag) — review mode applies its own rubric; no focus prompt.
+- **The codex-companion runtime's per-worktree broker dies mid-run** in a multi-session,
+  restart-heavy workflow — it killed a 25-minute review that sat "running" forever.
+  Background work goes through `codex exec` only.
+- **Codex has auto-opened PRs and committed unprompted** — git stays with the driver.

--- a/plugins/ship/skills/router/SKILL.md
+++ b/plugins/ship/skills/router/SKILL.md
@@ -1,298 +1,142 @@
 ---
 name: router
-description: Use ONLY when executing the build tasks of an implementation plan (the BUILD stage of /ship) — dispatching each task to GPT-5.6 sol via background codex exec per Pete's current dial (see "Target mix" — currently 0/100, Opus is out of the BUILD rotation entirely; drafting is all sol, sub-overhead work inline on the driver; the dial is driver-independent — Fable or Opus 5 driving, drafting stays codex). Do NOT invoke for planning, design, review, merge, or normal work — that all stays on the driver (the harness model). Never route to Sonnet.
+description: Use ONLY when executing the build tasks of an implementation plan (the BUILD stage of /ship) — dispatching each coding task to GPT-5.6 sol via background codex exec. Fable always drives (every stage, including BUILD) and dispenses the coding tasks; sub-overhead work stays inline on the driver. Do NOT invoke for planning, design, review, merge, or normal work — that all stays on the driver. Never route to Sonnet.
 ---
 
-# router — split BUILD-stage coding across Opus and GPT-5.6 sol
+# router — the driver dispenses BUILD coding to GPT-5.6 sol
 
-**Scope: the BUILD stage only.** Discover, plan, design, merge, and every normal
-task stay on **the driver** — the harness model running the session (Fable
-today; Opus 5 once Fable's quota is up — see driver succession under "Target
-mix") — as usual; do not invoke router for them. Router fires *only* when the driver is
-dispatching the concrete build tasks of an already-written implementation plan.
-Outside build, there is no routing decision. (Ship's other codex offloads —
-adversarial review in REVIEW, mechanical recon in DISCOVER — are wired directly
-in the ship skill, not through router. The constant everywhere: **design,
-planning, and the final say stay with Fable**; codex is inference muscle.)
+**Scope: the BUILD stage only.** Discover, plan, design, merge, and every normal task
+stay on the driver; router fires only when dispatching the concrete build tasks of an
+already-written implementation plan. (Ship's other codex offloads — review mode in
+REVIEW, recon in DISCOVER, verify's browser walks — are wired directly in the ship
+skill; the invoke rules below apply to them all the same.)
 
-Two engines:
+**The dial (Pete, 2026-07-28): Fable always drives — every stage, including BUILD — and
+dispenses the coding tasks to codex.** Driver tokens buy judgment (design, briefs,
+triage, gates, git, the final say); codex tokens buy drafts — codex does markedly better
+work under a well-authored brief, and brief-writing is what the driver excels at.
+**Never route to Sonnet** — retired from this pipeline entirely. The dial is a target,
+not a quota: *"use your judgment and make sure you get the job done, that's what's
+important."* If a task wants different handling, follow the task and log why.
 
-- **GPT-5.6 sol** — via **background `codex exec`**, billing the ChatGPT
-  subscription. Off-Max entirely. (For Anthropic-model offloads, never shell
-  out to `claude -p` from inside a session — use harness subagents via the
-  Agent tool: same models, same Max billing, native tracking. `claude -p` is
-  fine ToS-wise but belongs in scripts/cron, not inside a run.) **Fast mode stays
-  OFF** (Pete, 2026-07-13: Fast burned credits ~2.5× for ~1.5× speed); xhigh
-  stays the effort floor — save credits on the *tier*, never on thinking.
-  *(The 2026-07-16 claudex experiment — sol in the Claude Code harness via a
-  loopback proxy — is reversed as of 2026-07-18, Pete's call: clumsy in
-  practice, and the codex CLI's own network path is faster. The claudex install
-  survives for interactive use, but ship never dispatches through it.)*
-- **Opus** *(dormant at the current 0/100 dial — kept for when Pete swings it
-  back)* — an Opus subagent: `Agent(model: opus)` in Claude Code; under Codex
-  Desktop, an Opus-capable subagent tool if the harness exposes one (search the
-  available tools first) — if none, keep the task on the driver and log
-  `driver-no-opus`. On Claude Max, drawing on the weekly Opus quota.
-
-**Never route to Sonnet** — Sonnet 5 is retired from this pipeline entirely (Pete's
-call), whatever the current mix.
-
-**The mix is Pete's dial, not a constant.** He retunes it as quota reality changes
-(it has swung from 50/50 to 95/5 codex and back inside a week). The current dial
-lives in **"Target mix"** below — when Pete says "go X/Y," that section (and this
-description) is the only thing to edit. The heuristics, discipline, and patience
-rules below hold at any mix.
-
-**Auth caveat:** the savings only hold if `codex` uses its *subscription*
-login, not an API key — an `OPENAI_API_KEY` in the env would silently bill
-per-call. Sanity-check on first use in a session.
-
-## Prime directive: success over the mix
-
-The dial is a **target, not a quota.** You (the driver) decide each assignment —
-optimize for the work getting done *well*, and **self-adjust freely** as the ledger
-shows what works. If a task wants a different engine than the split suggests, follow
-the task and log why. Pete: *"use your judgment and make sure you get the job done,
-that's what's important."*
-
-## The two engines
-
-| Engine | Invoke | Best at |
-|--------|--------|---------|
-| **GPT-5.6 sol** | `codex exec -c model_reasoning_effort=xhigh -o <result-file> "<brief>" < /dev/null` (cwd = repo worktree, background; see quick-reference) | Fully-specified, self-contained coding with real work to explore: figure out signatures, write tests against real types, work through a well-briefed problem. "Here's exactly what to build" → it builds it well |
-| **Opus** *(dormant at 0/100)* | `Agent(model: opus)` | Judgment and integration: design still open mid-task, cross-file integration, real risk, irreversible surfaces, ambiguity a brief can't close — at the current dial that work is the driver's, not Opus's |
-
-**You (the driver) dial thinking per task — and default to MORE thinking, not
-less.** sol workers: `xhigh` unless you have a reason to drop (credits are real but
-thinking is the cheap part — the expensive mistake is a shallow wrong draft; spend
-it). Opus subagents: `high` floor, `xhigh` for the gnarly ones; go lower only for
-genuinely mechanical work. **Slow is fine — the answer to an engine taking a while
-is a longer timeout, not less thinking or a different engine** (see the patience
-note).
-
-## Target mix  ← Pete's dial — edit here when he retunes it
-
-**Current dial (2026-07-11): Opus 0 / GPT-5.6 sol 100 — Opus 4.8 is out of the
-BUILD rotation entirely (Pete's call).** All drafting goes to GPT-5.6 sol; there
-is no per-task engine choice, only dispatch-vs-inline (heuristic #4). A task that
-would have wanted Opus-grade judgment doesn't get a different engine — it gets
-a **tighter brief**: the driver closes the open design question itself, then
-dispatches the fully-specified remainder; if the judgment can't be separated
-from the writing, the driver does that task inline. **Fable has the final say
-at any mix** — the driver owns design, planning, briefs, triage, and merge; the
-dial only moves who drafts the code.
-
-**Driver succession (Pete, 2026-07-28): the dial is driver-independent.** Pete
-drives /ship on Fable until its quota runs out, then switches the driver to
-**Opus 5** — and BUILD drafting stays 100% codex either way. An Opus 5 driver
-does *not* put Opus back in the drafting rotation; whoever drives, their quota
-is spent only on judgment — briefs, triage, gates, git, the final say. That's
-the economics of the split: codex does markedly better work under a
-well-authored brief, brief-writing is exactly what the driver excels at, so
-driver tokens buy guidance while codex tokens buy drafts — stretching both
-subscriptions as far as they'll go. (The all-Fable build dial some 2026-07-23
-ledger rows cite was Pete's temporary call for that run; as of 2026-07-28 he's
-retuned it back to all-codex — that memory is retired.)
-
-**Harness (2026-07-18, Pete's call): sol drafts through `codex exec`** — the
-one-day claudex detour (07-16→07-18) is over; codex's native network path is
-faster and the wrapper felt clumsy. One engine, one invoke shape, for drafting
-and browser work alike.
-
-**Browser work is codex's too (Pete, 2026-07-11):** verify walks, design QA,
-and live-product grounding dispatch as background `codex exec` — codex scripts
-its own Playwright and saves screenshots to disk. Auth-walled surfaces: codex
-attaches to the dedicated logged-in **codex Chrome**
-(`~/.codex/codex-chrome`, CDP :9222) via `connectOverCDP`. Opus's only
-remaining pipeline job is claude-in-chrome against Pete's *personal* Chrome,
-for logins that exist nowhere else.
+**Billing:** codex bills the ChatGPT subscription — the savings hold only on its
+*subscription* login; an `OPENAI_API_KEY` in the env silently bills per-call
+(sanity-check on first use). **Fast mode stays OFF** (burned credits ~2.5× for ~1.5×
+speed); **xhigh is the effort floor** — save credits on the tier, never on thinking.
+For Anthropic-model offloads, never shell out to `claude -p` from inside a session —
+use harness subagents (the Agent tool): same models, same Max billing, native tracking.
+`claude -p` belongs in scripts/cron, not inside a run.
 
 ## The assignment heuristic
 
-For each build task, ask in order:
+For each build task, in order:
 
-1. **Design still open, real risk, irreversible, ambiguous mid-flight?** → the
-   **driver closes the judgment first** (decide the design, pick the shape,
-   settle the ambiguity), then dispatches the now-fully-specified task to sol.
-   Judgment inseparable from the writing → the driver does the task inline.
-2. **Fully specified and self-contained, with real work to explore** — exact
-   files, signatures, test cases, no open design questions? → **GPT-5.6 sol
-   (codex exec, xhigh).** At the current dial this is the default destination
-   for everything.
-3. *(dormant at 0/100)* When the dial has two engines, solid well-specified
-   coding that fits either balances the split.
-4. **Smaller than the dispatch overhead?** → the **driver writes it inline**.
-   A dispatch costs ~5–10 min of fixed overhead (brief, launch, poll, read
-   result) — a verbatim write already authored in the brief, a rename, a config
-   line, wiring a triaged review fix all finish faster on the driver than the
-   overhead alone (Pete's amendment to conserve-Fable, 2026-07-06). Anything
-   with real exploration or multi-file work still dispatches.
-5. **The sol worker produced a *wrong* diff twice on a task?** → escalate to
-   **the driver** — Fable rewrites the task inline (at 0/100 there is no Opus
-   bench; a third sol round costs more than it saves), log `escalated→driver`.
-   **Slow is not failure** — never escalate (or kill a run) because a worker is
-   taking a while.
-6. **Agent-skill / craft prose AND frontend design — never routed.** SKILL.md
-   files, reference/verb docs, agent-voiced distillations are **driver-authored**
-   (Fable), not sent to codex or Opus (Pete's dial, 2026-07-02) — the voice and
-   judgment *are* the deliverable. Same for **frontend design** (Pete's call,
-   2026-07-18, reversing 2026-07-16): HTML design specs, mockups, visual/UI
-   work, styling — anywhere taste is the deliverable — Fable authors inline.
-   Frontend *mechanics* with the design already closed (wiring a spec'd
-   component, plumbing per an approved design) route to sol like any other
-   closed-brief task.
+1. **Design still open, real risk, ambiguous?** → the driver closes the judgment first
+   (decide the design, settle the ambiguity), then dispatches the fully-specified
+   remainder. Judgment inseparable from the writing → the driver does the task inline.
+2. **Fully specified and self-contained, with real work to explore?** → **GPT-5.6 sol**
+   (`codex exec`, xhigh). The default destination for drafting.
+3. **Smaller than the dispatch overhead (~5–10 min: brief, launch, poll, read)?** → the
+   driver writes it inline. A rename, a config line, a verbatim write already authored
+   in the brief, wiring a triaged review fix — all finish faster than the overhead.
+   Real multi-file exploration still dispatches.
+4. **A wrong diff twice on the same task?** → escalate: the driver rewrites inline; log
+   `escalated→driver`. A third codex round costs more than it saves. **Slow is not
+   failure** — never escalate because a worker is taking a while.
+5. **Skill/agent prose and frontend design — never routed.** SKILL.md files, agent-
+   voiced docs, HTML design specs, mockups, styling — anywhere taste is the
+   deliverable — the driver authors inline. Frontend *mechanics* with the design closed
+   route like any other closed-brief task.
 
-### Patience note (hard-won — read before dispatching sol)
+**Browser work is codex's, always** — verify walks, design QA, live-product grounding:
+codex scripts its own Playwright, saves screenshots to disk. Auth-walled: the logged-in
+codex Chrome (`~/.codex/codex-chrome`, CDP :9222) via `connectOverCDP`. Never drive
+the browser from the driver.
 
-A sol worker can sit quiet for many minutes at xhigh — past
-runs were killed at a 2-minute timeout before a single file was written, and those
-got mislogged as failures. They weren't; they were impatience. **We have time:
-dispatch in the background and give it a generous window — think 15–30 minutes,
-not 2 — checking in on it rather than killing it.** Don't drop effort to make it
-faster; xhigh + patience is the deal. The one true exception: **work smaller than
-the dispatch overhead** — that's not a dispatch task at any speed, the driver
-writes it inline (heuristic #4).
+## Patience & liveness
 
-### Tag and track every dispatch
+An xhigh worker can sit quiet for many minutes — runs killed at a 2-minute timeout were
+healthy and got mislogged as failures. **Dispatch in the background with a generous
+window (15–30 min), checking in rather than killing.** Don't drop effort to go faster.
 
-Pete runs concurrent sessions dispatching workers at once — untagged and
-untracked, a hung run sits unnoticed until someone wonders why a task never
-landed (it has happened). So:
+- **Startup liveness tell:** a healthy `codex exec` creates its `~/.codex/sessions`
+  rollout file within seconds. Process alive with no session file after ~2 min = dead
+  at startup (held stdin, bad flag) — kill and redispatch. Distinct from "slow is
+  fine," which applies only after the session exists.
+- **Stall budget: ~15 min of silence → an active look** (process in `ps`? result file
+  or working tree moving?). A live run that's just slow gets left alone. A run that
+  exited without a result, or shows zero output and zero writes: kill the chain,
+  `codex exec resume <session-id>` if it left a session, else redispatch `-retry1`,
+  and log the row honestly.
 
-- **Tag:** the first line of every brief is
+## Tag and track every dispatch
+
+Pete runs concurrent sessions; untagged hung runs sit unnoticed.
+
+- **Tag:** first line of every brief is
   `[ship-dispatch: <project> · <branch> · <task-slug>]` (append `-retryN` on
-  redispatch). The brief rides in `codex exec`'s argv, so the tag shows in
-  `ps aux | grep "codex exec"` — any session, and Pete, can attribute every
-  run at a glance. Tell the worker in the brief that the tag line is routing
-  metadata to ignore.
-- **Track:** dispatch with the harness's `run_in_background` (it notifies on
-  exit) and check in at intervals. **Startup liveness tell:** a healthy
-  `codex exec` creates its `~/.codex/sessions` rollout file within seconds.
-  Process alive with no session file after ~2 min = dead at startup (stdin
-  held open, bad flag), kill and redispatch — this is distinct from "slow is
-  fine", which applies only after the session exists. **Every dispatch carries
-  a stall budget: ~15 minutes of silence → an active look** (is the process in
-  `ps`? has the result file or the run's working tree moved?) — never more
-  passive waiting. Patience (15–30 min) is for **live** runs — the process
-  exists and its output or the working tree is moving; a live run that's just
-  slow gets left alone. A run that exited without a result, or a stall-budget
-  check finding zero output and zero file writes, is not a patience case: kill
-  the process chain, `codex exec resume <session-id>` if it left a session,
-  else redispatch with `-retry1`, and log the row honestly (`abandoned` or
-  `fixed-N`, note "hung"). The stall budget converts "stuck forever" into
-  "lost 15 minutes."
+  redispatch) — it rides in argv, so `ps aux | grep "codex exec"` attributes every run.
+  Tell the worker the tag is routing metadata to ignore.
+- **Track:** dispatch with the harness's `run_in_background` (notifies on exit) —
+  never a hand-rolled `&`.
 
-## The discipline (non-negotiable, both engines)
+## The discipline (non-negotiable)
 
-Whoever drafts the code, **the driver owns the envelope**:
+Whoever drafts, **the driver owns the envelope**:
 
-1. **The driver writes the brief** — exact files, signatures, test cases,
-   constraints. A vague brief to codex wastes the savings in fix rounds.
-2. **The driver reviews the diff** and **runs the gates** (tsc / tests / build)
-   before anything is committed. Never trust a "tests pass" claim — re-run them.
-   This holds for Opus-subagent output too.
-3. **The driver owns git** — commits, merges, branch hygiene. (Codex has
-   auto-opened PRs / committed unprompted before — rein it in; git stays with
-   the driver.)
-4. **One writer per branch at a time.** Never run two writers — an Opus subagent
-   and/or a codex task — against the same working tree concurrently; they collide
-   (it has caused git collisions). Serialize them, or give each its own
-   sub-worktree.
+1. **The driver writes the brief** — exact files, signatures, test cases, constraints.
+   A vague brief wastes the savings in fix rounds.
+2. **The driver reviews the diff and runs the gates** before anything is committed —
+   never trust a "tests pass" claim.
+3. **The driver owns git** — codex has auto-opened PRs and committed unprompted; rein
+   it in.
+4. **One writer per branch at a time** — concurrent writers on one working tree
+   collide. Serialize, or give each its own sub-worktree.
 
-The split is about *who drafts the code*, not about skipping review. Quality bar
-is identical across both engines.
+## CLI quick-reference
 
-## CLI / invoke quick-reference
-
-**Codex (GPT-5.6 sol via `codex exec`) — the drafting dispatch, and the standing
-engine for review mode and browser work (wired in the ship skill):**
 ```
 cd <repo> && codex exec -c model_reasoning_effort=xhigh -o <result-file> "<full task brief>" < /dev/null
 ```
-launched in the background — in Claude Code the Bash tool's `run_in_background`
-(it notifies on exit); under Codex Desktop a long-lived shell session you poll.
-Never a hand-rolled `&`.
+
 - **`-o <result-file>` on every dispatch** (e.g. `/tmp/ship-<task-slug>-result.md`) —
-  it writes the agent's final message to a file, so the result survives even if
-  the shell buffer is truncated or the watcher misses the exit. Read the file,
-  not the scrollback.
-- **`< /dev/null` is mandatory.** When stdin isn't a TTY, `codex exec` blocks
-  reading stdin to EOF *before doing anything* — a held-open pipe hangs the run
-  at startup forever, with no session file and no error (this ate a night of
-  dispatches once and got misblamed on fast mode/xhigh).
-- **cwd outside a git repo → add `--skip-git-repo-check`**, or codex exits
-  fatally at startup ("Not inside a trusted directory").
-- **Always the sol variant.** GPT-5.6 in this pipeline means `gpt-5.6-sol`,
-  never plain `gpt-5.6` or another variant (Pete's call, 2026-07-11). If a
-  dispatch ever needs the model set explicitly, it's `-m gpt-5.6-sol`.
-- Leave the model unset so the run inherits `~/.codex/config.toml` (gpt-5.6-sol,
-  standard tier — Fast mode is OFF to conserve credits; don't override either).
-- First line of the brief is the `[ship-dispatch: …]` tag (see "Tag and track
-  every dispatch") so the run is attributable in `ps`.
-- Fix rounds: resume the *specific* session — capture the session id codex
-  prints, then `codex exec resume <session-id> "<follow-up>"`. **Never
-  `resume --last`** — with concurrent sessions dispatching codex, "--last" is
-  whichever run finished most recently anywhere on the machine, not your task.
-- Edits the working tree directly → obey "one writer per branch."
+  the result survives a truncated buffer or missed exit. Read the file, not scrollback.
+- **`< /dev/null` is mandatory** — a held-open stdin hangs `codex exec` at startup
+  forever, no session file, no error.
+- **cwd outside a git repo → `--skip-git-repo-check`**, or codex exits fatally.
+- **Always the sol variant** — `gpt-5.6-sol`, never plain `gpt-5.6`. Leave the model
+  unset to inherit `~/.codex/config.toml` (sol, standard tier); if it must be explicit,
+  `-m gpt-5.6-sol`.
+- Fix rounds: capture the session id and `codex exec resume <session-id>
+  "<follow-up>"`. **Never `resume --last`** — with concurrent sessions it's whichever
+  run finished most recently anywhere on the machine.
 - **Reviews use codex's native review mode, not a hand-rolled brief:**
-  `codex exec review --base <branch> -o <result-file> < /dev/null`
-  (or `--uncommitted` / `--commit <sha>`). **No positional prompt** — codex
-  errors ("cannot be used with [PROMPT]") when a prompt is combined with any
-  diff-source flag; review mode applies its own rubric. No prompt also means
-  no ship-dispatch tag — name the `-o` result file after the feature slug so
-  the run is attributable in `ps`. Review mode is read-only by
-  construction and computes the diff itself — "edit nothing" enforced by the
-  tool, not by prompt convention.
-- **Do NOT use the codex-companion runtime (`codex` plugin's
-  `codex-companion.mjs task/status/result`) for background work.** Its jobs
-  depend on a per-worktree broker daemon that the plugin's SessionEnd hook
-  tears down — in Pete's multi-session, restart-heavy workflow the broker dies
-  mid-run and the job sits "running" forever, orphaned (it killed a 25-minute
-  review). Companion is acceptable only for short *foreground* calls you'll
-  outlive; `codex exec` is the path for everything dispatched. Never go through
-  the `codex:codex-rescue` subagent either (Sonnet forwarder; Sonnet is
-  retired).
+  `codex exec review --base <branch> -o <result-file> < /dev/null` (or
+  `--uncommitted` / `--commit <sha>`). **No positional prompt** — codex errors when a
+  prompt is combined with any diff-source flag. No prompt means no dispatch tag — name
+  the `-o` file after the slug instead. Read-only by construction.
+- **Never the codex-companion runtime for background work** — its per-worktree broker
+  daemon dies mid-run in a multi-session workflow and the job orphans "running"
+  forever. Companion only for short foreground calls; `codex exec` for everything
+  dispatched. Never the `codex:codex-rescue` subagent (Sonnet forwarder; retired).
 
-**Opus:**
-```
-Agent(model: opus, prompt: "<full task brief>")   // Claude Code
-```
-- Codex Desktop: use an Opus-capable subagent tool if one is exposed; otherwise keep
-  the task on the driver and log the engine as `driver-no-opus` in the ledger.
+## The ledger
 
-## The metric — the ledger
+Maintain `~/.claude/skills/router/ledger.md` — the single canonical ledger, outside any
+repo or plugin directory (an installed plugin isn't writable state). **After every
+delegated build task**, append a row:
 
-Maintain `~/.claude/skills/router/ledger.md` — the **single canonical ledger**,
-outside any repo or plugin directory (create it there if missing; never write a
-ledger into the plugin's own directory — an installed plugin isn't writable state).
-**After every delegated build task**, append a row and keep the rolling summary
-current.
+`date | project | task (short) | task-type | engine | outcome | fix-rounds | note`
 
-Row: `date | project | task (short) | task-type | engine | outcome | fix-rounds | note`
-
-- **engine**: `codex` · `opus`
 - **task-type**: `specific-coding` · `integration` · `mechanical`
-- **outcome**: `clean` (passed review + gates first pass) · `fixed-N` (N
-  review→fix cycles) · `escalated→driver` (the sol worker couldn't; the driver
-  rewrote inline) · `abandoned`
-- Headline metric: **first-pass-clean rate per engine and per task-type**, plus
-  **escalation rate.**
+- **outcome**: `clean` · `fixed-N` · `escalated→driver` · `abandoned`
+- Headline metric: **first-pass-clean rate per task-type**, plus escalation rate. A
+  task-type that keeps escalating stays on the driver — say so when reporting a plan's
+  execution.
 
-**How to tune the split:** every so often (or when Pete asks), read the ledger:
-- an engine cleaning a task-type first-pass → send it *more* of that type.
-- a task-type that keeps getting `escalated→driver` → keep that type on the
-  driver and say so when reporting the mix.
-- Report realized mix vs the current dial and per-engine hit-rates when
-  summarizing a plan's execution.
+## When NOT to delegate (driver-inline, always)
 
-The mix is Pete's dial; the ledger is the evidence; refine over time.
-
-## When NOT to delegate (keep on the driver or Opus)
-
-- Anything touching auth, secrets, money, migrations, or irreversible / outward-
-  facing actions → Opus (or the driver directly).
-- Anything where the spec is still fuzzy (clarify/plan first — that's not a build
-  task yet).
-- Tiny verbatim writes where the content is *already authored* in the brief
-  (driver-inline is faster than spinning up any subagent).
-- The final review of a branch, and all of git → the driver, always.
+- Auth, secrets, money, migrations, irreversible or outward-facing actions.
+- A still-fuzzy spec (clarify/plan first — that's not a build task yet).
+- Tiny verbatim writes already authored in the brief.
+- The final review of a branch, and all of git.

--- a/specs/designs/2026-07-28-pipeline-diet.html
+++ b/specs/designs/2026-07-28-pipeline-diet.html
@@ -1,0 +1,208 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Instruction Layers × /ship — Design Brief</title>
+<style>
+  :root {
+    --bg: #faf9f7; --ink: #1a1a1a; --muted: #6b6b6b; --line: #e4e1db;
+    --accent: #b4552d; --good: #2d7a4f; --bad: #b03030; --warn: #a07617;
+    --card: #ffffff; --code-bg: #f0eee9;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg: #161513; --ink: #e8e6e1; --muted: #9a978f; --line: #2e2c28;
+      --accent: #e07a4a; --good: #5bbd8a; --bad: #e06c6c; --warn: #d9b04a;
+      --card: #1e1d1a; --code-bg: #26241f; }
+  }
+  * { box-sizing: border-box; margin: 0; }
+  body { background: var(--bg); color: var(--ink);
+    font: 16px/1.65 -apple-system, "SF Pro Text", Segoe UI, sans-serif;
+    max-width: 880px; margin: 0 auto; padding: 3rem 1.5rem 6rem; }
+  h1 { font-size: 1.9rem; line-height: 1.2; letter-spacing: -0.02em; margin-bottom: .4rem; }
+  h2 { font-size: 1.25rem; margin: 3rem 0 1rem; padding-top: 1.5rem; border-top: 1px solid var(--line); letter-spacing: -0.01em; }
+  h3 { font-size: 1rem; margin: 1.6rem 0 .5rem; }
+  p { margin: .7rem 0; }
+  .kicker { color: var(--accent); font-weight: 600; font-size: .8rem; text-transform: uppercase; letter-spacing: .08em; }
+  .sub { color: var(--muted); font-size: .95rem; }
+  .tldr { background: var(--card); border: 1px solid var(--line); border-left: 4px solid var(--accent);
+    border-radius: 8px; padding: 1.1rem 1.3rem; margin: 1.8rem 0; }
+  .tldr p { margin: .5rem 0; }
+  code { background: var(--code-bg); border-radius: 4px; padding: .1em .35em; font-size: .85em;
+    font-family: "SF Mono", ui-monospace, Menlo, monospace; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; font-size: .88rem; }
+  .tablewrap { overflow-x: auto; }
+  th { text-align: left; font-size: .72rem; text-transform: uppercase; letter-spacing: .06em; color: var(--muted);
+    padding: .5rem .7rem; border-bottom: 2px solid var(--line); }
+  td { padding: .55rem .7rem; border-bottom: 1px solid var(--line); vertical-align: top; }
+  .sev { font-weight: 700; white-space: nowrap; }
+  .sev.hard { color: var(--bad); } .sev.drift { color: var(--warn); } .sev.dup { color: var(--muted); }
+  .stack { display: flex; flex-direction: column; gap: 6px; margin: 1.2rem 0; }
+  .layer { background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: .7rem 1rem; }
+  .layer b { display: block; font-size: .92rem; }
+  .layer span { color: var(--muted); font-size: .84rem; }
+  .layer.hot { border-color: var(--accent); }
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1rem 0; }
+  @media (max-width: 640px) { .grid2 { grid-template-columns: 1fr; } }
+  .panel { background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 1rem 1.2rem; }
+  .panel h3 { margin-top: 0; }
+  .panel.good h3 { color: var(--good); } .panel.bad h3 { color: var(--bad); }
+  ul { padding-left: 1.2rem; margin: .5rem 0; }
+  li { margin: .35rem 0; }
+  blockquote { border-left: 3px solid var(--accent); margin: 1rem 0; padding: .3rem 0 .3rem 1rem;
+    color: var(--muted); font-style: italic; }
+  .pill { display: inline-block; font-size: .7rem; font-weight: 700; text-transform: uppercase; letter-spacing: .05em;
+    border-radius: 999px; padding: .1em .6em; margin-right: .4em; }
+  .pill.do { background: color-mix(in srgb, var(--good) 15%, transparent); color: var(--good); }
+  .pill.fork { background: color-mix(in srgb, var(--accent) 15%, transparent); color: var(--accent); }
+  .footnote { color: var(--muted); font-size: .82rem; margin-top: 2.5rem; border-top: 1px solid var(--line); padding-top: 1rem; }
+</style>
+</head>
+<body>
+
+<p class="kicker">Design Brief · 2026-07-28</p>
+<h1>The instruction stack vs. /ship</h1>
+<p class="sub">How the CLAUDE.md layers on this machine cooperate with — and fight — the ship pipeline, and what the Fable 5 prompting guidance changes.</p>
+
+<div class="tldr">
+  <p><b>The verdict:</b> the architecture is right — global taste, plugin process, per-repo facts — but the layers have drifted into <b>4 direct contradictions, ~7 duplicated rule-sets, and one live dial that the skill files no longer describe</b>. And the Fable 5 guidance lands squarely on ship's biggest file: <i>"Skills developed for prior models are often too prescriptive for Claude Fable 5 and can degrade output quality."</i> The pipeline skill is 7,800 words with a prohibition every 110 words — much of it steering behavior Fable now does by default.</p>
+  <p><b>The move:</b> resolve the 4 contradictions (3 are one-line edits, 1 is your call), put ship's per-repo knowledge into a small "ship contract" section in each repo's CLAUDE.md instead of hardcoding homezero into the global plugin, and put the pipeline skill on a Fable 5 diet — keep the machine contracts byte-exact, compress the behavioral steering into short principles, move the war stories to an appendix.</p>
+</div>
+
+<h2>1 · The stack as it exists today</h2>
+<p>Six layers speak into every /ship run. Ordered from most-global to most-local:</p>
+
+<div class="stack">
+  <div class="layer"><b>Fable 5 harness system prompt</b><span>Now ships several behaviors verbatim that lower layers also instruct: "when you have enough information to act, act," autonomous-operation rules, evidence-grounded progress claims, brevity-by-selectivity. New since the guide.</span></div>
+  <div class="layer"><b>~/.claude/CLAUDE.md (global)</b><span>Taste + invariants: tone dial 7, worktree-always, PR + squash flow, HTML design docs, default stack, "don't hand me non-decisions."</span></div>
+  <div class="layer"><b>Hooks + superpowers</b><span>Ponytail (full) injected at session and subagent start; superpowers skills with mandatory language (brainstorming before ANY creative work, TDD always).</span></div>
+  <div class="layer hot"><b>ship plugin — pipeline / router / verify</b><span>12k words, 99 hard prohibitions, ~18 incident-derived rules, 3 machine-parsed output contracts (<code>.ship-stage</code>, <code>needs input:</code>/<code>result:</code> lines, verify's 5-field verdict).</span></div>
+  <div class="layer"><b>Project CLAUDE.md / AGENTS.md (13 active)</b><span>Bimodal: 2 repos feed ship everything it needs (homezero, ship itself); 4 give a bare test command; 7 give nothing. 4 of 13 are entirely machine-generated stubs.</span></div>
+  <div class="layer"><b>Memories + router ledger</b><span>Where the live truth now lives — including a dial change (<code>ship-engine-all-fable</code>) the skill files don't reflect.</span></div>
+</div>
+
+<div class="grid2">
+  <div class="panel good">
+    <h3>What's genuinely working</h3>
+    <ul>
+      <li><b>The one declared contract works.</b> Ship names exactly one CLAUDE.md dependency — the standing stack, repo file overrides — and it matches the global file exactly. "The plugin is the process; your stack is you" is the right seam.</li>
+      <li><b>homezero is the model case.</b> Its AGENTS.md names /ship as the flow, declares the CI gate, npm-only, deploy lanes, and the prod-send footgun. When ship runs there it has everything.</li>
+      <li><b>verify is already Fable-5-shaped.</b> The guide's #1 scaffolding rec — fresh-context verifier subagents over self-critique — is verify's founding axiom.</li>
+      <li><b>The machine contracts are real infrastructure.</b> Status line, shipboard, and FleetView parse them. These are the parts that must survive any rewrite byte-exact.</li>
+    </ul>
+  </div>
+  <div class="panel bad">
+    <h3>What's rotting</h3>
+    <ul>
+      <li><b>cells + wells are dead (Pete-confirmed) but still instrumented as alive:</b> <code>cells/CLAUDE.md</code> sits in the active Projects tree, and the <code>cells</code> and <code>wells</code> skills are still registered globally — every session carries triggers for infrastructure that no longer exists.</li>
+      <li><b>notes/CLAUDE.md</b> points at a nonexistent <code>~/Projects/CLAUDE.md</code> and still lists wells/cells as active projects.</li>
+      <li><b>Zero/CLAUDE.md</b> names two in-flight worktrees that are gone, and half-duplicates homezero's deploy-lane table (already drifting).</li>
+      <li><b>imessage/CLAUDE.md</b> has a plaintext password in it.</li>
+      <li><b>buzz</b> documents that Tauri <code>cargo fmt</code> fails inside git worktrees — a landmine directly under the worktree-always rule if /ship ever fires there. Nothing connects the two facts.</li>
+    </ul>
+  </div>
+</div>
+
+<h2>2 · The conflicts</h2>
+<p>Ranked. <span class="sev hard">HARD</span> = the two layers literally command opposite things. <span class="sev drift">DRIFT</span> = the file no longer matches operating reality. <span class="sev dup">DUP</span> = same rule stated in two places, waiting to diverge.</p>
+
+<div class="tablewrap"><table>
+  <tr><th></th><th>Global / other layer says</th><th>ship says</th><th>Read</th></tr>
+  <tr><td class="sev hard">HARD</td>
+    <td>"Every feature/fix lands through a GitHub PR — don't squash-merge straight to local main anymore."</td>
+    <td>EXPRESS lane: <code>wt merge</code> — which is precisely a local squash to main, no PR.</td>
+    <td><b>Your call.</b> You moved to PR-flow deliberately; either EXPRESS opens a fast PR too, or the global gets an explicit EXPRESS carve-out. Pick one, write it down once.</td></tr>
+  <tr><td class="sev hard">HARD</td>
+    <td>"Design docs, specs, AND implementation plans are self-contained HTML files."</td>
+    <td>"The execution plan is machine-facing markdown he never reads" — and in practice ship's plans are <code>specs/plans/*.md</code>.</td>
+    <td>Ship is right. The global rule was written for docs <i>you</i> read. One-line fix to the global: machine-facing plans may be markdown.</td></tr>
+  <tr><td class="sev hard">HARD</td>
+    <td>Global Billing: Max OAuth via <code>claude -p</code> is fine; "Fable reviews may use <code>claude -p --model fable</code>."</td>
+    <td>Router: "never <code>claude -p</code> … Max OAuth for agent work is a ToS violation."</td>
+    <td>Router is stale on both fact and policy. Delete the line.</td></tr>
+  <tr><td class="sev hard">HARD</td>
+    <td>Superpowers: brainstorming "before ANY creative work," TDD "for any feature or bugfix" — mandatory language.</td>
+    <td>EXPRESS and SELF-DIRECTED skip brainstorming; "No strict TDD by default."</td>
+    <td>Ship's posture is the one you actually run — but it never says it's overriding. Add one line: "this pipeline overrides the superpowers brainstorming/TDD defaults on autonomous lanes." Silent bypass of MUST-language is exactly what confuses a strong instruction-follower.</td></tr>
+  <tr><td class="sev drift">DRIFT</td>
+    <td>Memory <code>ship-engine-all-fable</code> + router ledger (2026-07-23): "all-Fable dial supersedes router 0/100; killed a codex dispatch, building inline."</td>
+    <td>Router + pipeline both still say all drafting goes to GPT-5.6 sol at 0/100.</td>
+    <td><b>The biggest single item.</b> The engine ladder's whole premise — "conserve Fable, it's the scarcest inference" — predates Fable being the everyday driver. Decide the standing dial; if all-Fable is it, router shrinks to dispatch mechanics for verify/review offloads and the ladder prose goes.</td></tr>
+  <tr><td class="sev drift">DRIFT</td>
+    <td>Ponytail hook fires on every subagent: "code first, at most three short lines."</td>
+    <td>Ship's subagent briefs demand storyboards, 7-section cards, fixed verdict schemas.</td>
+    <td>Ship's structured outputs are contracts, so they win — but the two fight in every subagent's context. Exempt ship-dispatched subagents from the ponytail hook, or state the precedence in the brief template.</td></tr>
+  <tr><td class="sev drift">DRIFT</td>
+    <td>"Don't hand me non-decisions."</td>
+    <td>GATE 2 fires unconditionally after PLAN — the skill itself admits it's "often zero calls — then it's a pure confirm."</td>
+    <td>A hard stop that's sometimes a non-decision. Option: GATE 2 auto-passes when the go-card has zero calls and the lane isn't schema/auth/money. Your taste call — it removes a checkpoint.</td></tr>
+  <tr><td class="sev dup">DUP</td>
+    <td colspan="2">Stated in both global and pipeline: docs-home rule, html-effectiveness patterns + URL, "who Pete is" PM framing, squash + <code>--delete-branch</code> choreography, auto-<code>open</code> artifacts, the six-name stack list. Pipeline even restates the engine dial right after saying "router owns it, don't restate it here."</td>
+    <td>Each fact should live in one layer; the lower layer references, never restates. Every duplicate is a future drift (the billing one above <i>was</i> one of these).</td></tr>
+  <tr><td class="sev dup">DUP</td>
+    <td colspan="2">Deploy-lane knowledge lives in both Zero/CLAUDE.md and homezero/AGENTS.md at different detail levels; Zero's copy already has dead references.</td>
+    <td>AGENTS.md owns it; Zero points.</td></tr>
+</table></div>
+
+<h2>3 · What the Fable 5 guidance changes</h2>
+<p>The platform doc (the "new ways of prompting" — this is the written form of what Thariq's been saying) has one recommendation aimed straight at this setup:</p>
+<blockquote>"Refactor existing prompts and skills. Skills developed for prior models are often too prescriptive for Claude Fable 5 and can degrade output quality. Review and consider removing older instructions if default performance is better."</blockquote>
+<p>Pipeline SKILL.md is the poster child: 70 "never"s, ~176 bold spans, 18 rules that are incident post-mortems turned into permanent prose. The guide's counter-pattern: <b>one short principle now steers what used to take an enumerated list</b> — instruction-following is strong enough that listing every banned behavior is worse than stating the intent.</p>
+
+<h3>Three-way triplication</h3>
+<p>Several behaviors are now stated <b>three times</b> — in the Fable harness system prompt, in the global CLAUDE.md, and again in ship: act-don't-overplan, evidence-grounded status reports, pause-only-for-genuine-input, brevity. The harness copy is maintained by Anthropic and always current; the other two copies are now redundancy that can only drift.</p>
+
+<h3>Sorting the pipeline's 7,800 words</h3>
+<div class="tablewrap"><table>
+  <tr><th>Bucket</th><th>What it is</th><th>Fable 5 treatment</th></tr>
+  <tr><td><b>Machine contracts</b></td><td><code>.ship-stage</code> markers, <code>needs input:</code>/<code>result:</code> + branch·worktree suffix, verify's 5-field verdict, card templates.</td><td><b>Keep byte-exact.</b> Parsed by statusline, shipboard, FleetView. Label them as machine contracts so the model knows they're not prose style.</td></tr>
+  <tr><td><b>Environment facts</b></td><td>codex stdin hang, <code>--merged</code> vs UI-squash, worktree/<code>gh pr merge</code> interactions, Convex preview drift, workflow-concurrency cancellation.</td><td><b>Keep, but move to a reference appendix.</b> These are facts about the world, not behavior steering — Fable can pull them when relevant instead of carrying all 18 inline.</td></tr>
+  <tr><td><b>Behavior steering</b></td><td>Anti-idle rules, narration cadence, don't-overplan, options-with-a-rec phrasing, "most runs teach nothing," brevity rules.</td><td><b>Compress hard.</b> Most of this is now native or one sentence. This is where "too prescriptive degrades output" bites.</td></tr>
+  <tr><td><b>Process spine</b></td><td>Lanes, two gates, the gate test ("would Pete's answer change what gets built"), scope law, stage order.</td><td><b>Keep — this is the actual design.</b> The gate test and scope law are exactly the kind of short principle the guide says to prefer. They're already well-written.</td></tr>
+</table></div>
+
+<h3>Other guide items that map here</h3>
+<ul>
+  <li><b>Memory:</b> the guide's per-lesson-file pattern is already your harness memory + router ledger + ship-retro issues — three systems. The failure mode showed up already: a memory changed the engine dial and no skill file followed. Design rule: <b>a memory that changes a dial triggers a skill edit</b> (the retro path exists for exactly this; use it).</li>
+  <li><b>Reasoning echo:</b> ship's "log why" ledger rows are fine (decision logs, not reasoning transcripts) — nothing here trips the reasoning-extraction refusal category. One less migration worry.</li>
+  <li><b>Effort:</b> router's "xhigh is the floor" was written for codex; with Fable driving, the guide says lower efforts often beat old-model xhigh — the all-Fable decision changes the economics the ladder was built on.</li>
+</ul>
+
+<h2>4 · Target architecture</h2>
+<p><b>One fact, one layer.</b> Each layer states only what it uniquely knows; lower layers reference upward, never restate.</p>
+<ul>
+  <li><b>Global CLAUDE.md</b> — taste and cross-repo invariants only. Drops what the Fable harness now ships (autonomy, evidence-grounding). Gains two one-liners: machine-facing plans may be markdown; the EXPRESS merge ruling (whichever way you call it).</li>
+  <li><b>ship plugin</b> — the process spine + machine contracts + environment-fact appendix. Loses: restated global rules, restated dial, homezero hardcoding (7 mentions), stale billing claim, behavioral steering Fable does natively. Gains: an explicit "overrides superpowers brainstorming/TDD on autonomous lanes" line.</li>
+  <li><b>Project CLAUDE.md — a small "ship contract" section</b>, the real design idea here. Ship currently knows homezero by name; instead every shippable repo declares:
+    <ul>
+      <li><code>gates:</code> the test/build commands that must be green</li>
+      <li><code>lanes:</code> deploy commands per lane (or "none")</li>
+      <li><code>preview:</code> how to provision an isolated backend (the clobbering-bug seam)</li>
+      <li><code>verify-auth:</code> the test-auth path verify may use</li>
+      <li><code>ship: no</code> — for van, mayor-pete, notes, paonia/PKAI, so the pipeline declines cleanly instead of improvising</li>
+    </ul>
+    homezero already has all of this in prose; this just names the seam so the plugin reads it instead of embedding it. buzz's contract would carry its worktree-breaking fmt gotcha where ship would actually see it.</li>
+  <li><b>Memories/ledger</b> — observations and dial history; any standing change flows into the owning skill file within the run that made it.</li>
+</ul>
+
+<h2>5 · Punch list</h2>
+<h3><span class="pill do">Just do</span> No taste required</h3>
+<ul>
+  <li>Delete router's stale Max-OAuth/ToS claim.</li>
+  <li>Global one-liner: machine-facing execution plans may be markdown.</li>
+  <li>Ship one-liner: declares its superpowers overrides explicitly.</li>
+  <li>Hygiene sweep: move <code>~/Projects/cells</code> to <code>archived/</code> and unregister the <code>cells</code>/<code>wells</code> skills (both dead per Pete); fix notes/CLAUDE.md's dead pointers and stale project list; Zero/CLAUDE.md dead worktree names + dedupe the lane table; move the imessage password out of the file.</li>
+  <li>De-duplicate the seven restated global rules out of pipeline (reference, don't restate).</li>
+</ul>
+<h3><span class="pill fork">Your call</span> Genuine forks</h3>
+<ul>
+  <li><b>EXPRESS merge:</b> PRs-for-everything (consistency, audit trail, ~30s overhead per tweak) vs. keep <code>wt merge</code> as a sanctioned carve-out (fastest path for watched tweaks). <b>Rec: fast PR even on EXPRESS</b> — you chose PR-flow for a reason, and ship already has the choreography.</li>
+  <li><b>Engine dial:</b> ratify all-Fable as the standing dial (router shrinks to dispatch mechanics; the "conserve Fable" ladder retires) vs. restore 0/100 codex. <b>Rec: ratify all-Fable</b> — it's what you're actually running, and the ladder's premise is obsolete now that Fable is the driver.</li>
+  <li><b>GATE 2 auto-pass</b> when the go-card has zero calls (non-schema/auth/money): removes a checkpoint that's sometimes a pure confirm, at the cost of one fewer look before build. <b>Rec: yes, with the schema/auth/money exclusion.</b></li>
+  <li><b>Pipeline diet itself:</b> the restructure in §3 is a real /ship run on the ship repo — worth doing as its own ship once the forks above are called, so the rewrite lands the rulings in one pass.</li>
+</ul>
+
+<p class="footnote">Sources: Fable 5 prompting guide (platform.claude.com); full reads of pipeline/router/verify SKILL.md, the ship plugin repo, and all 13 active project CLAUDE.md files (+ worktree copies, confirmed identical). Conflict quotes verbatim from the files. This brief is analysis only — no files were edited.</p>
+
+</body>
+</html>


### PR DESCRIPTION
Anthropic's Fable 5 guidance: skills written for prior models are often
too prescriptive and degrade output. Sorted the pipeline's 7.8k words into
machine contracts (kept byte-exact), environment facts (new
reference/incidents.md), process spine (kept), and behavioral steering
(compressed — the harness does this natively now).

Rulings landed: EXPRESS merges via fast PR (wt merge only for no-remote
repos); GATE 2 auto-passes on zero-call go-cards (schema/auth included
unless genuinely necessary; money always stops); Fable always drives —
every stage including BUILD — dispensing coding tasks to codex (no Opus
driver succession); superpowers brainstorming/TDD overrides now declared
explicitly instead of silently bypassed. Homezero hardcoding replaced by
a per-repo 'ship contract' seam; restated global rules deduped. Design
record: specs/designs/2026-07-28-pipeline-diet.html.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016yVPMC6AZVtmnrwq3ozg4v
