### PR TITLE
Restore the codex router for BUILD — reverses the 08-10 retirement, scoped to drafting

### DIFF
--- a/plugins/ship/skills/pipeline/SKILL.md
+++ b/plugins/ship/skills/pipeline/SKILL.md
@@ -82,30 +82,15 @@ a gate. Never use an autonomous lane to slip a taste call past Pete.
 
 ## Engines
 
-**Everything runs inside Claude Code** (Pete, 2026-08-10 — codex retired from the
-pipeline; the separate `router` skill retired with it). The driver owns design, briefs,
-triage, gates, git, and the final say, and **dispenses closed-brief coding tasks to
-harness subagents** (the Agent tool — same models, same Max billing, native tracking,
-notifies on exit). Work smaller than the dispatch overhead, the driver writes inline.
-Never shell out to `claude -p` from inside a session — that's for scripts and cron.
-Never Sonnet.
-
-**What delegates, what stays inline** — in order, per build task:
-
-1. **Design still open, real risk, ambiguous?** → the driver closes the judgment first,
-   then dispatches the fully-specified remainder. Judgment inseparable from the
-   writing → the driver does it inline.
-2. **Fully specified and self-contained, with real work to explore?** → **subagent**.
-   The default destination for drafting.
-3. **Smaller than the dispatch overhead** (writing the brief + reading the result)? →
-   inline. A rename, a config line, a verbatim write already authored in the brief,
-   wiring a triaged review fix. Real multi-file exploration still dispatches.
-4. **A wrong diff twice on the same task?** → the driver rewrites it inline. **Slow is
-   not failure** — never escalate because a subagent is taking a while.
-5. **Skill/agent prose and frontend design — never delegated.** SKILL.md files,
-   agent-voiced docs, HTML design specs, mockups, styling — anywhere taste is the
-   deliverable, the driver authors inline. Frontend *mechanics* with the design closed
-   delegate like any other closed brief.
+**Fable always drives — every stage, including BUILD** (Pete, 2026-07-28; codex
+dispatch restored 2026-08-12, reversing the 08-10 all-Claude retirement). The driver
+owns design, briefs, triage, gates, git, and the final say; it **dispenses the plan's
+coding tasks to GPT-5.6 sol** via background `codex exec` — the `router` skill owns
+the dispatch mechanics, the assignment heuristic (what dispatches vs stays inline),
+and the ledger. Work smaller than a dispatch's ~5–10 min fixed overhead, the driver
+writes inline; skill/agent prose and design taste never route. For Anthropic-model
+offloads (recon, verify walks, review fan-outs), use harness subagents (the Agent
+tool) — never `claude -p` from inside a session. Never Sonnet.
 
 **The driver owns the envelope**, whoever drafts: it writes the brief (exact files,
 signatures, test cases, constraints — a vague brief burns the savings in fix rounds),
@@ -118,7 +103,8 @@ grounding. A subagent drives the MCP browser tools against the running app and r
 what it saw; never drive the browser from the driver while other work is in flight.
 Auth-walled surfaces need no special rig: Pete's own Chrome is already logged in.
 
-**Never idle while a subagent runs** — a review or QA pass is 10–25 minutes.
+**Never idle while a dispatch or subagent runs** — a codex draft, review, or QA pass
+is 10–25 minutes.
 Work the standing non-tree list meanwhile (draft the review card, the board update, the
 commit message, groom `/ship next` cards) so the stage closes minutes after the result
 lands. Same posture at gates: notify, then keep doing non-gated work.
@@ -291,10 +277,10 @@ on main.
 
 - Write `build:0:<M>`; bump N per task. Build **all M tasks** in one session; commit
   each task on the branch as it lands, merge only when the whole plan is built.
-- Invoke `superpowers:subagent-driven-development` (the driver drives) and dispatch
-  each task per **Engines** above — closed briefs to subagents, sub-overhead work
-  inline. The driver owns the brief, the diff review, the gates, and git. One writer
-  per branch at a time.
+- Invoke `superpowers:subagent-driven-development` (the driver drives) and `router` to
+  dispatch each task — drafting goes to codex per the router's heuristic; sub-overhead
+  work inline. The driver owns the brief, the diff review, the gates, and git. One
+  writer per branch at a time.
 - **Single-writer vs fan-out — pick by the diff, not reflex.** Default one writer.
   Fan out writers (own worktrees, merged back) only for genuinely independent AND
   numerous tasks — a migration, a mechanical sweep. The high-value fan-out is the
@@ -302,9 +288,9 @@ on main.
   parallelize 5 verifiers.
 - `ponytail` posture; `superpowers:verification-before-completion` before claiming any
   task done — actually run it; `superpowers:systematic-debugging` on a red test.
-- **UI-writing briefs carry the craft floor** — a subagent loads its own skills, not
-  the driver's open ones, so the floor never reaches the writer unless the brief points
-  it there: every dispatch that writes UI tells the writer to read
+- **UI-writing briefs carry the craft floor** — codex has no impeccable installed, so
+  the floor never reaches the writer unless the brief points it there: every dispatch
+  that writes UI tells codex to read
   `~/.claude/skills/impeccable/reference/craft-floor.md` and honor its checks and bans.
 - **Before BUILD is done, smoke-walk the whole feature yourself** — boot the app and
   drive the spec's real user paths (the formal `verify` runs in REVIEW; don't invoke it

--- a/plugins/ship/skills/router/SKILL.md
+++ b/plugins/ship/skills/router/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: router
+description: Use ONLY when executing the build tasks of an implementation plan (the BUILD stage of /ship) — dispatching each coding task to GPT-5.6 sol via background codex exec. Fable always drives (every stage, including BUILD) and dispenses the coding tasks; sub-overhead work stays inline on the driver. Do NOT invoke for planning, design, review, merge, or normal work — that all stays on the driver. Never route to Sonnet.
+---
+
+# router — the driver dispenses BUILD coding to GPT-5.6 sol
+
+**Scope: the BUILD stage only.** Discover, plan, design, merge, and every normal task
+stay on the driver; router fires only when dispatching the concrete build tasks of an
+already-written implementation plan. (Ship's other codex offloads — review mode in
+REVIEW, recon in DISCOVER, verify's browser walks — are wired directly in the ship
+skill; the invoke rules below apply to them all the same.)
+
+**The dial (Pete, 2026-07-28): Fable always drives — every stage, including BUILD — and
+dispenses the coding tasks to codex.** Driver tokens buy judgment (design, briefs,
+triage, gates, git, the final say); codex tokens buy drafts — codex does markedly better
+work under a well-authored brief, and brief-writing is what the driver excels at.
+**Never route to Sonnet** — retired from this pipeline entirely. The dial is a target,
+not a quota: *"use your judgment and make sure you get the job done, that's what's
+important."* If a task wants different handling, follow the task and log why.
+
+**Billing:** codex bills the ChatGPT subscription — the savings hold only on its
+*subscription* login; an `OPENAI_API_KEY` in the env silently bills per-call
+(sanity-check on first use). **Fast mode is ON for ship dispatches** (Pete, 2026-08-01,
+reversing the 07-13 cost ruling — the ~2.5× credit burn for ~1.5× speed is accepted):
+add `-c fast_mode=true` to every dispatch; the global `~/.codex/config.toml` keeps
+`fast_mode = false` for interactive use. **Effort: high** (Pete, 2026-08-01, down from
+xhigh — paired with fast mode, xhigh's long thinks were eating the speed win). Watch
+the ledger's first-pass-clean rate; a task-type that degrades goes back to xhigh.
+For Anthropic-model offloads, never shell out to `claude -p` from inside a session —
+use harness subagents (the Agent tool): same models, same Max billing, native tracking.
+`claude -p` belongs in scripts/cron, not inside a run.
+
+## The assignment heuristic
+
+For each build task, in order:
+
+1. **Design still open, real risk, ambiguous?** → the driver closes the judgment first
+   (decide the design, settle the ambiguity), then dispatches the fully-specified
+   remainder. Judgment inseparable from the writing → the driver does the task inline.
+2. **Fully specified and self-contained, with real work to explore?** → **GPT-5.6 sol**
+   (`codex exec`, high). The default destination for drafting.
+3. **Smaller than the dispatch overhead (~5–10 min: brief, launch, poll, read)?** → the
+   driver writes it inline. A rename, a config line, a verbatim write already authored
+   in the brief, wiring a triaged review fix — all finish faster than the overhead.
+   Real multi-file exploration still dispatches.
+4. **A wrong diff twice on the same task?** → escalate: the driver rewrites inline; log
+   `escalated→driver`. A third codex round costs more than it saves. **Slow is not
+   failure** — never escalate because a worker is taking a while.
+5. **Skill/agent prose and frontend design — never routed.** SKILL.md files, agent-
+   voiced docs, HTML design specs, mockups, styling — anywhere taste is the
+   deliverable — the driver authors inline. Frontend *mechanics* with the design closed
+   route like any other closed-brief task.
+
+**Browser work does NOT route here** (narrowed in the 2026-08-12 restore — router was
+retired 2026-08-10, brought back by Pete for build drafting only) — verify walks,
+design QA, and live-product grounding run on claude-in-chrome via harness subagents,
+per the ship skill's Engines. Router routes coding drafts, nothing else.
+
+## Patience & liveness
+
+A high-effort worker can sit quiet for many minutes — runs killed at a 2-minute timeout were
+healthy and got mislogged as failures. **Dispatch in the background with a generous
+window (15–30 min), checking in rather than killing.** Don't drop effort to go faster.
+
+- **Startup liveness tell:** a healthy `codex exec` creates its `~/.codex/sessions`
+  rollout file within seconds. Process alive with no session file after ~2 min = dead
+  at startup (held stdin, bad flag) — kill and redispatch. Distinct from "slow is
+  fine," which applies only after the session exists.
+- **Stall budget: ~15 min of silence → an active look** (process in `ps`? result file
+  or working tree moving?). A live run that's just slow gets left alone. A run that
+  exited without a result, or shows zero output and zero writes: kill the chain,
+  `codex exec resume <session-id>` if it left a session, else redispatch `-retry1`,
+  and log the row honestly.
+
+## Tag and track every dispatch
+
+Pete runs concurrent sessions; untagged hung runs sit unnoticed.
+
+- **Tag:** first line of every brief is
+  `[ship-dispatch: <project> · <branch> · <task-slug>]` (append `-retryN` on
+  redispatch) — it rides in argv, so `ps aux | grep "codex exec"` attributes every run.
+  Tell the worker the tag is routing metadata to ignore.
+- **Track:** dispatch with the harness's `run_in_background` (notifies on exit) —
+  never a hand-rolled `&`.
+
+## The discipline (non-negotiable)
+
+Whoever drafts, **the driver owns the envelope**:
+
+1. **The driver writes the brief** — exact files, signatures, test cases, constraints.
+   A vague brief wastes the savings in fix rounds.
+2. **The driver reviews the diff and runs the gates** before anything is committed —
+   never trust a "tests pass" claim.
+3. **The driver owns git** — codex has auto-opened PRs and committed unprompted; rein
+   it in.
+4. **One writer per branch at a time** — concurrent writers on one working tree
+   collide. Serialize, or give each its own sub-worktree.
+
+## CLI quick-reference
+
+```
+cd <repo> && codex exec -c model_reasoning_effort=high -c fast_mode=true -o <result-file> "<full task brief>" < /dev/null
+```
+
+- **`-o <result-file>` on every dispatch** (e.g. `/tmp/ship-<task-slug>-result.md`) —
+  the result survives a truncated buffer or missed exit. Read the file, not scrollback.
+- **`< /dev/null` is mandatory** — a held-open stdin hangs `codex exec` at startup
+  forever, no session file, no error.
+- **cwd outside a git repo → `--skip-git-repo-check`**, or codex exits fatally.
+- **Always the sol variant** — `gpt-5.6-sol`, never plain `gpt-5.6`. Leave the model
+  unset to inherit `~/.codex/config.toml` (sol, standard tier); if it must be explicit,
+  `-m gpt-5.6-sol`.
+- Fix rounds: capture the session id and `codex exec resume <session-id>
+  "<follow-up>"`. **Never `resume --last`** — with concurrent sessions it's whichever
+  run finished most recently anywhere on the machine.
+- **Reviews use codex's native review mode, not a hand-rolled brief:**
+  `codex exec review --base <branch> -o <result-file> < /dev/null` (or
+  `--uncommitted` / `--commit <sha>`). **No positional prompt** — codex errors when a
+  prompt is combined with any diff-source flag. No prompt means no dispatch tag — name
+  the `-o` file after the slug instead. Read-only by construction.
+- **Never the codex-companion runtime for background work** — its per-worktree broker
+  daemon dies mid-run in a multi-session workflow and the job orphans "running"
+  forever. Companion only for short foreground calls; `codex exec` for everything
+  dispatched. Never the `codex:codex-rescue` subagent (Sonnet forwarder; retired).
+
+## The ledger
+
+Maintain `~/.claude/skills/router/ledger.md` — the single canonical ledger, outside any
+repo or plugin directory (an installed plugin isn't writable state). **After every
+delegated build task**, append a row:
+
+`date | project | task (short) | task-type | engine | outcome | fix-rounds | note`
+
+- **task-type**: `specific-coding` · `integration` · `mechanical`
+- **outcome**: `clean` · `fixed-N` · `escalated→driver` · `abandoned`
+- Headline metric: **first-pass-clean rate per task-type**, plus escalation rate. A
+  task-type that keeps escalating stays on the driver — say so when reporting a plan's
+  execution.
+
+## When NOT to delegate (driver-inline, always)
+
+- Auth, secrets, money, migrations, irreversible or outward-facing actions.
+- A still-fuzzy spec (clarify/plan first — that's not a build task yet).
+- Tiny verbatim writes already authored in the brief.
+- The final review of a branch, and all of git.


### PR DESCRIPTION
Pete's call (2026-08-12): build drafting goes back to GPT-5.6 sol via
background codex exec, with the router skill restored as the dispatch
mechanics + ledger owner. Narrower than the pre-retirement wiring: browser
work (verify, design QA, grounding) stays on claude-in-chrome subagents and
correctness review stays /code-review — codex is back for coding drafts only.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QmWzgyvTpjvUG3LAyfqwZr
