### PR TITLE
Codex returns as a supervised worker — an Opus subagent per codex session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # ship — the /ship plugin repo
 
 The Claude Code plugin behind `/ship` (marketplace `peteknowsai/ship`). Skills live in
-`plugins/ship/skills/` (`pipeline` is /ship itself, plus `verify`). The bare
+`plugins/ship/skills/` (`pipeline` is /ship itself, plus `codex-supervisor` and `verify`). The bare
 `/ship` slash command is a *personal* command at `~/.claude/commands/ship.md` (a thin
 dispatcher to `ship:pipeline`) — plugin commands are always namespaced `plugin:command`,
 so a command in this repo would surface as the awkward `/ship:ship`. Don't add one back.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ It's opinionated. Built for a hands-off, PM-style workflow: you stay in your lan
 - **You read the meta, never the diff.** Every checkpoint auto-opens a condensed HTML card in your browser — a design spec, a go-card, and a **review card** at merge. Never "go read the PR."
 - **Gate notifications.** When a ship parks at a gate, a desktop notification taps you on the shoulder (Ghostty-native, with a macOS fallback) — so you can walk away.
 - **Stage-aware status line.** Which ship, what phase (`designing → planning → building → reviewing`), ships-in-flight, your context + weekly budget, effort level. A bold banner when a ship needs you.
-- **BUILD dispatched to subagents.** Each closed-brief build task goes to a harness subagent while the driver owns the brief, review, gates, and git. Everything stays inside Claude Code.
+- **BUILD supervised, not shelled out.** Each closed-brief build task goes to an Opus subagent that owns one codex session end to end — brief, launch, patience, fix rounds, verdict — while the driver owns the plan, the diff review, the gates, and git. Orchestration stays inside Claude Code; codex still does the drafting.
 - **Fresh-agent verification.** REVIEW invokes the bundled `verify` skill before the card so the running app is driven and judged before merge.
 
 ## What's in the plugin
 
 - `skills/ship` — the pipeline playbook + the go-card / review-card templates + the design record.
+- `skills/codex-supervisor` — how a subagent runs and babysits one codex task (bundled).
 - `skills/verify` — fresh read-only verification against the running app before merge.
 - `hooks/` — the gate desktop-notification hook.
 - `statusline.sh` — the stage-aware status line.

--- a/plugins/ship/plugin.json
+++ b/plugins/ship/plugin.json
@@ -1,11 +1,12 @@
 {
   "name": "ship",
-  "description": "/ship \u2014 take a feature from idea to merged in one command: worktree \u2192 discover \u2192 plan \u2192 build \u2192 review, gating only on design direction and 'go'. Auto-opening HTML design/go/review cards, gate desktop notifications, a stage-aware status line, BUILD dispatched to harness subagents, and fresh-agent verification before merge. Bundles verify.",
+  "description": "/ship \u2014 take a feature from idea to merged in one command: worktree \u2192 discover \u2192 plan \u2192 build \u2192 review, gating only on design direction and 'go'. Auto-opening HTML design/go/review cards, gate desktop notifications, a stage-aware status line, BUILD dispatched to Opus subagents that supervise codex runs, and fresh-agent verification before merge. Bundles codex-supervisor + verify.",
   "author": {
     "name": "Pete McCarthy"
   },
   "skills": [
     "./skills/pipeline",
+    "./skills/codex-supervisor",
     "./skills/verify"
   ],
   "hooks": "./hooks/hooks.json",

--- a/plugins/ship/skills/codex-supervisor/SKILL.md
+++ b/plugins/ship/skills/codex-supervisor/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: codex-supervisor
+description: Use when you are a subagent that has been handed one codex task to manage — a /ship BUILD task, correctness review, recon sweep, or browser walk. You own that codex session end to end: brief, launch, patience, fix rounds, verdict. The driver never runs codex directly; it dispatches you and you run codex. Do NOT invoke this on the driver, and do NOT invoke it for work that should be written inline.
+---
+
+# codex-supervisor — one subagent owns one codex session
+
+**You are the supervisor, not the author.** The driver handed you exactly one task and
+then stopped thinking about it. You author the brief, launch codex, wait it out, judge
+what comes back, run the fix rounds, and return a verdict the driver can act on without
+reading a line of your scrollback.
+
+**Why this shape** (Pete, 2026-08-10): codex tokens buy drafts, driver tokens buy
+judgment — and the *watching* is neither. Polling, stall checks, liveness tells, retries,
+a session id that has to be threaded through three commands: that noise used to land in
+the driver's context and crowd out the work. Now it lands in yours. You are cheap to
+spawn and cheap to throw away; the driver's context is the scarce thing.
+
+**You run on Opus.** You are judging a diff and deciding whether to press on or hand
+back — that is the judgment half of the job, and it is why a subagent supervises rather
+than a bare shell command.
+
+## Your contract with the driver
+
+Return, in your final message:
+
+1. **Verdict** — `clean` · `fixed-N` · `escalate` · `failed`.
+2. **What changed** — the actual file list, not a summary of intent.
+3. **Gates you ran yourself** and their real output (tsc, tests, lint — whatever the repo
+   has). Never pass along a codex claim that tests pass; run them.
+4. **What you did not do** — anything you skipped, guessed at, or left half-finished.
+
+Hard limits, no exceptions:
+
+- **Never commit, never push, never open a PR.** Git belongs to the driver. Codex has
+  auto-opened PRs and committed unprompted; if it does that inside your session, reset
+  the tree and say so in your verdict.
+- **Never widen scope.** A neighbouring bug you spot goes in the verdict as a note. It
+  does not go in the diff.
+- **Never touch a file outside the brief's stated set** without saying so explicitly.
+
+## Launch
+
+```
+cd <repo> && codex exec -c model_reasoning_effort=high -c fast_mode=true \
+  -o <result-file> "<full task brief>" < /dev/null
+```
+
+- **`< /dev/null` is mandatory.** A held-open stdin hangs `codex exec` at startup
+  forever — no session file, no error, no clue. This once ate a night of dispatches.
+- **`-o <result-file>` on every run** (e.g. `/tmp/ship-<task-slug>-result.md`). Read the
+  file, never the scrollback — the result survives a truncated buffer or a missed exit.
+- **Fast mode on, effort high** (Pete, 2026-08-01). The global `~/.codex/config.toml`
+  keeps `fast_mode = false` for interactive use, so pass it per dispatch.
+- **Always the sol variant** — leave the model unset to inherit `gpt-5.6-sol` from
+  config; if it must be explicit, `-m gpt-5.6-sol`. Never plain `gpt-5.6`.
+- **cwd outside a git repo → `--skip-git-repo-check`**, or codex exits fatally.
+- **Tag the brief's first line**: `[ship-dispatch: <project> · <branch> · <task-slug>]`
+  (append `-retryN` on redispatch). It rides in argv, so `ps aux | grep "codex exec"`
+  attributes every run across Pete's concurrent sessions. Tell codex the tag is routing
+  metadata to ignore.
+- **Dispatch with `run_in_background`**, never a hand-rolled `&`.
+- **Billing sanity-check on first use**: codex bills the ChatGPT subscription only on its
+  *subscription* login. An `OPENAI_API_KEY` in the env silently bills per call.
+
+**Reviews use codex's native review mode, not a hand-written brief:**
+`codex exec review --base <branch> -o <result-file> < /dev/null` (or `--uncommitted` /
+`--commit <sha>`). **No positional prompt** — codex errors when a prompt is combined with
+any diff-source flag, so there's no dispatch tag either; name the `-o` file after the
+slug instead. Read-only by construction.
+
+**Never the codex-companion runtime for background work** — its per-worktree broker
+daemon dies mid-run in a multi-session workflow and the job orphans "running" forever.
+Companion is for short foreground calls only.
+
+## Patience — the failure mode that fooled us for weeks
+
+A high-effort worker sits quiet for many minutes. Runs killed at a two-minute timeout
+were healthy and got logged as failures, which then made the engine look worse than it
+was. **Slow is not failure.** Give it 15–30 minutes and check in rather than killing.
+Never drop effort to go faster.
+
+- **Startup liveness tell:** a healthy `codex exec` writes its `~/.codex/sessions`
+  rollout file within seconds. Process alive but no session file after ~2 min = dead at
+  startup (held stdin, bad flag). Kill and redispatch. This is the *only* early kill.
+- **Stall budget: ~15 min of silence → an active look.** Is the process in `ps`? Is the
+  result file or the working tree moving? A live run that's merely slow gets left alone.
+  A run that exited with no result, or shows zero output and zero writes:
+  `codex exec resume <session-id>` if it left a session, else redispatch with `-retry1`.
+- **Never `resume --last`** — with concurrent sessions that's whichever run finished most
+  recently anywhere on the machine, which is usually somebody else's task. Capture the
+  session id at launch and resume by id.
+
+## Fix rounds, and when to stop
+
+You own up to **two** fix rounds. Resume the session with a specific, narrow follow-up —
+what's wrong, which file, what the correct behaviour is. Vague follow-ups produce vague
+diffs.
+
+**A wrong diff twice on the same task → stop and `escalate`.** A third round costs more
+than it saves. Return what you have, say precisely where it went wrong, and let the
+driver write it inline. Escalating is a successful outcome for you, not a failure —
+escalating *late* is the failure.
+
+## Hand back instead of pressing on
+
+Return `escalate` immediately, without burning rounds, when:
+
+- The brief turns out to be ambiguous or the design isn't actually closed — you are not
+  the right agent to settle a design question.
+- The task touches auth, secrets, money, migrations, or anything irreversible or
+  outward-facing. Those never leave the driver in the first place; if one reached you,
+  the brief was wrong.
+- The work turns out to be taste-shaped — skill prose, agent-voiced docs, HTML design
+  specs, mockups, styling. Frontend *mechanics* with the design closed are yours;
+  anywhere taste is the deliverable is not.
+- Codex needs repo knowledge the brief doesn't carry and you'd be guessing.
+
+## Browser walks
+
+When your task is a browser walk (verify, design QA, live-product grounding), codex
+scripts and runs its own Playwright against the running app and saves screenshots to
+real files. The brief must open with **"READ-ONLY: edit no source files"** — a plain
+`codex exec` has no tool-enforced read-only the way review mode does, so the constraint
+lives in the brief and you check `git status` in the worktree afterwards. Any dirt →
+discard it and count the round `unverifiable`.
+
+Auth-walled surfaces: codex attaches to the logged-in codex Chrome
+(`~/.codex/codex-chrome`, CDP :9222) via `chromium.connectOverCDP` and drives real
+logged-in tabs. Launch it first if `curl -s http://127.0.0.1:9222/json/version` says it's
+down; if the site isn't logged in there yet, hand back and ask for a one-time login —
+sessions persist after that. A login that exists **only** in Pete's personal Chrome is
+the one case that leaves codex entirely: say so, and the driver takes it with
+claude-in-chrome.
+
+**The seeded account is yours alone while a walk is in flight.** Concurrent clicks from
+anyone else read as bugs — a shared account once produced a false `broken` that cost a
+whole diagnosis round.
+
+## The ledger
+
+Append one row per task to `~/.claude/skills/router/ledger.md` — the canonical ledger,
+kept outside any repo or plugin directory because an installed plugin isn't writable
+state:
+
+`date | project | task (short) | task-type | engine | outcome | fix-rounds | note`
+
+- **task-type**: `specific-coding` · `integration` · `mechanical`
+- **outcome**: `clean` · `fixed-N` · `escalated→driver` · `abandoned`
+
+The metric that matters is **first-pass-clean rate per task-type**, plus escalation rate.
+A task-type that keeps escalating should stop being dispatched — say so in your verdict
+when you notice it, so the driver can stop sending that shape of work here.

--- a/plugins/ship/skills/pipeline/SKILL.md
+++ b/plugins/ship/skills/pipeline/SKILL.md
@@ -66,7 +66,7 @@ gate genuinely needs him.** What scales is the ceremony, and **you size it, not 
   visual. Pete finds out from the `result:` line, not before.
 - **SELF-DIRECTED — real work with no taste question in it.** Write whatever
   machine-facing spec/plan *you* need to build it well, then build, run the full REVIEW
-  machinery (`/code-review` + `verify` — a `works` verdict is the merge bar), merge,
+  machinery (codex review + `verify` — a `works` verdict is the merge bar), merge,
   deploy to dev, `result:`. **Zero stops — the artifacts are for the record, not
   approval.**
 - **GATED — Pete's taste or direction is genuinely in play.** A new user-facing
@@ -82,43 +82,56 @@ a gate. Never use an autonomous lane to slip a taste call past Pete.
 
 ## Engines
 
-**Everything runs inside Claude Code** (Pete, 2026-08-10 — codex retired from the
-pipeline; the separate `router` skill retired with it). The driver owns design, briefs,
-triage, gates, git, and the final say, and **dispenses closed-brief coding tasks to
-harness subagents** (the Agent tool — same models, same Max billing, native tracking,
-notifies on exit). Work smaller than the dispatch overhead, the driver writes inline.
-Never shell out to `claude -p` from inside a session — that's for scripts and cron.
+**Everything is orchestrated from inside Claude Code** (Pete, 2026-08-10). The driver
+dispatches only to **harness subagents** — it never runs `codex exec` itself, never
+shells out to `claude -p`, and never watches a background process. Some subagents do the
+work themselves; others are **codex supervisors**: an Opus subagent that owns one codex
+session end to end (brief → launch → patience → fix rounds → verdict) per the
+`codex-supervisor` skill. Codex tokens still buy the drafts; the supervisor absorbs the
+polling, the stall checks, and the retries that used to crowd the driver's context.
 Never Sonnet.
+
+**Two dispatch shapes:**
+
+- **Codex supervisor (Opus → codex)** — the default for closed-brief drafting,
+  correctness review, recon sweeps, and browser walks. Anything with real work to
+  explore and no open design question.
+- **Plain Claude subagent** — when repo context or taste is load-bearing enough that
+  handing it to codex would cost more in fix rounds than it saves.
 
 **What delegates, what stays inline** — in order, per build task:
 
 1. **Design still open, real risk, ambiguous?** → the driver closes the judgment first,
    then dispatches the fully-specified remainder. Judgment inseparable from the
    writing → the driver does it inline.
-2. **Fully specified and self-contained, with real work to explore?** → **subagent**.
-   The default destination for drafting.
-3. **Smaller than the dispatch overhead** (writing the brief + reading the result)? →
+2. **Fully specified and self-contained, with real work to explore?** → **codex
+   supervisor**. The default destination for drafting.
+3. **Smaller than the dispatch overhead** (brief + supervise + read the verdict)? →
    inline. A rename, a config line, a verbatim write already authored in the brief,
    wiring a triaged review fix. Real multi-file exploration still dispatches.
-4. **A wrong diff twice on the same task?** → the driver rewrites it inline. **Slow is
-   not failure** — never escalate because a subagent is taking a while.
+4. **A supervisor returns `escalate`?** → the driver writes it inline, now, and logs
+   why. Don't re-dispatch the same task a third time. **Slow is not failure** — never
+   escalate because a run is taking a while; that judgment belongs to the supervisor.
 5. **Skill/agent prose and frontend design — never delegated.** SKILL.md files,
    agent-voiced docs, HTML design specs, mockups, styling — anywhere taste is the
    deliverable, the driver authors inline. Frontend *mechanics* with the design closed
-   delegate like any other closed brief.
+   dispatch like any other closed brief.
 
-**The driver owns the envelope**, whoever drafts: it writes the brief (exact files,
-signatures, test cases, constraints — a vague brief burns the savings in fix rounds),
-reviews the diff and runs the gates before anything is committed (never trust a "tests
-pass" claim), and owns git entirely. **One writer per branch at a time** — concurrent
-writers on one tree collide; serialize, or give each its own sub-worktree.
+**The driver owns the envelope**, whoever drafts: it writes the brief the supervisor
+carries (exact files, signatures, test cases, constraints — a vague brief burns the
+savings in fix rounds), reviews the returned diff and runs the gates before anything is
+committed (never trust a "tests pass" claim, from a supervisor or from codex), and owns
+git entirely. **One writer per branch at a time** — concurrent writers on one tree
+collide; serialize, or give each its own sub-worktree.
 
-**All browser work runs on claude-in-chrome** — verify walks, design QA, live-product
-grounding. A subagent drives the MCP browser tools against the running app and reports
-what it saw; never drive the browser from the driver while other work is in flight.
-Auth-walled surfaces need no special rig: Pete's own Chrome is already logged in.
+**All browser work goes through a supervisor too** — verify walks, design QA,
+live-product grounding: codex scripts its own Playwright against the running app and
+saves screenshots to disk. Auth-walled surfaces use the logged-in codex Chrome
+(`~/.codex/codex-chrome`, CDP :9222). The one exception that never reaches codex: a
+login that exists solely in Pete's *personal* Chrome — that's a driver-side
+claude-in-chrome walk.
 
-**Never idle while a subagent runs** — a review or QA pass is 10–25 minutes.
+**Never idle while a supervisor runs** — a review or QA pass is 10–25 minutes.
 Work the standing non-tree list meanwhile (draft the review card, the board update, the
 commit message, groom `/ship next` cards) so the stage closes minutes after the result
 lands. Same posture at gates: notify, then keep doing non-gated work.
@@ -190,9 +203,9 @@ on main.
 ### 1 · DISCOVER — Pete's taste, up front  → marker: `discover`, then `gate:1`
 
 - Invoke `superpowers:brainstorming`. PM-framed, one question at a time.
-- **Recon runs on a subagent, synthesis stays with the driver.** Codebase
-  evidence-gathering dispatches to a read-only `Explore` subagent (report findings,
-  edit nothing).
+- **Recon runs on a supervisor, synthesis stays with the driver.** Codebase
+  evidence-gathering dispatches as a read-only codex run (report findings, edit
+  nothing).
   The recon brief includes a **reuse audit**: for every core noun the feature
   introduces, grep the whole repo — data layer included — for existing infra before the
   plan treats it as new (incidents: Design).
@@ -202,9 +215,9 @@ on main.
   the repo's PRODUCT.md/DESIGN.md are the visual authority): a new surface or
   replacement look routes through its `shape`/new-work path; a refinement stays on the
   incumbent world. Use `/pix` for imagery freely — the spec *is* the prototype.
-  **Ground the design in the live product**: a subagent walks the running app /
-  deployed URL over claude-in-chrome and reports the real theme/CSS with screenshots;
-  design from those, never from in-repo mockups (incidents: Design).
+  **Ground the design in the live product**: a supervisor walks the running app /
+  deployed URL and reports the real theme/CSS with screenshots; design from those,
+  never from in-repo mockups (incidents: Design).
 - Produce ONE self-contained HTML spec in the repo's docs home (`specs/` or `docs/`,
   whichever it uses) — e.g. `specs/designs/YYYY-MM-DD-<slug>.html` — covering the
   **whole** feature; it's the scope contract PLAN and BUILD execute in full.
@@ -235,9 +248,9 @@ on main.
 - Write `build:0:<M>`; bump N per task. Build **all M tasks** in one session; commit
   each task on the branch as it lands, merge only when the whole plan is built.
 - Invoke `superpowers:subagent-driven-development` (the driver drives) and dispatch
-  each task per **Engines** above — closed briefs to subagents, sub-overhead work
-  inline. The driver owns the brief, the diff review, the gates, and git. One writer
-  per branch at a time.
+  each task per **Engines** above — closed briefs to codex supervisors, sub-overhead
+  work inline. The driver owns the brief, the diff review, the gates, and git. One
+  writer per branch at a time.
 - **Single-writer vs fan-out — pick by the diff, not reflex.** Default one writer.
   Fan out writers (own worktrees, merged back) only for genuinely independent AND
   numerous tasks — a migration, a mechanical sweep. The high-value fan-out is the
@@ -245,10 +258,11 @@ on main.
   parallelize 5 verifiers.
 - `ponytail` posture; `superpowers:verification-before-completion` before claiming any
   task done — actually run it; `superpowers:systematic-debugging` on a red test.
-- **UI-writing briefs carry the craft floor** — a subagent loads its own skills, not
-  the driver's open ones, so the floor never reaches the writer unless the brief points
-  it there: every dispatch that writes UI tells the writer to read
-  `~/.claude/skills/impeccable/reference/craft-floor.md` and honor its checks and bans.
+- **UI-writing briefs carry the craft floor** — codex has no impeccable installed and
+  a subagent loads its own skills, not the driver's, so the floor never reaches the
+  writer unless the brief points it there: every dispatch that writes UI carries
+  `~/.claude/skills/impeccable/reference/craft-floor.md` down to the writer, with its
+  checks and bans.
 - **Before BUILD is done, smoke-walk the whole feature yourself** — boot the app and
   drive the spec's real user paths (the formal `verify` runs in REVIEW; don't invoke it
   twice). Two preconditions that have each cost a red deploy (incidents: Backends): a
@@ -265,12 +279,14 @@ on main.
 - **Freeze the tree while a verifier is driving** — no merges, rebases, or edits until
   its verdict lands (incidents: Worktrees). Absorb upstream *before* dispatching a
   round, never during.
-- **Correctness review — `/code-review` against the lane target, launched first** so
-  it works while the rest of REVIEW proceeds. Meanwhile the driver runs
-  `ponytail-review` (the over-build sweep). The **driver triages every finding** —
-  adversarial reviewers over-flag by design — fixes what's real, puts judgment calls on
-  the card. The high-value fan-out is here: several verifiers on one diff beats one.
-- **Design QA for visual features** — a background subagent first runs
+- **Correctness review — a supervisor on codex review mode, launched first** so it
+  works while the rest of REVIEW proceeds (`codex exec review --base <lane-target>`;
+  the supervisor owns the mechanics). Meanwhile the driver runs `ponytail-review` (the
+  over-build sweep). The **driver triages every finding** — adversarial reviewers
+  over-flag by design — fixes what's real, puts judgment calls on the card. Codex
+  unavailable → `/code-review` + `ponytail-review` on the driver. The high-value
+  fan-out is here: several verifiers on one diff beats one.
+- **Design QA for visual features** — a background supervisor first runs
   impeccable's deterministic detector over the branch's changed UI files
   (`node ~/.claude/skills/impeccable/scripts/detect.mjs --json <files>` — local, no
   network), then walks the built surfaces and judges them against the GATE 1 spec and
@@ -283,8 +299,8 @@ on main.
   live local app is on his screen. **Never deploy to let him review; never tell him to
   "go look at the live site"** — the worktree's localhost is the review surface.
   (Non-UI change → show the demo/test output instead.)
-- **Prove it works — invoke `verify` before the card.** A fresh read-only subagent
-  verifier drives the feature and returns `works | broken | unverifiable` + a
+- **Prove it works — invoke `verify` before the card.** A fresh read-only supervisor
+  drives the feature and returns `works | broken | unverifiable` + a
   screenshot storyboard; verify loops-to-fix (cap ~3). **`broken` after the cap, or
   `unverifiable` → do NOT merge**: end the turn with `needs input:` ("review: <feature>
   — couldn't prove it works: <reason>") and hand Pete the verdict + evidence.

--- a/plugins/ship/skills/pipeline/reference/incidents.md
+++ b/plugins/ship/skills/pipeline/reference/incidents.md
@@ -65,17 +65,29 @@ These are facts, not process — the process lives in SKILL.md.
 
 ## Dispatch
 
-(Codex was retired from the pipeline on 2026-08-10; its CLI-specific incidents went with
-it. These are the lessons that outlived the engine.)
+(The `codex-supervisor` skill carries the operational rules; these are the underlying
+incidents. The driver no longer runs codex directly — a supervisor subagent does — but
+the failures below are why the rules exist.)
 
+- **`codex exec` with stdin held open hangs at startup forever** — no session file, no
+  error. It once ate a night of dispatches and got misblamed on fast mode. `< /dev/null`
+  is mandatory.
 - **Runs killed at a 2-minute timeout got mislogged as failures** — they were healthy
-  high-effort runs that hadn't written anything yet. **Slow is not failure.** Give a
-  dispatch a generous window and check in rather than killing; escalate on a wrong diff,
-  never on a slow one.
-- **A worker has auto-opened PRs and committed unprompted** — git stays with the driver,
-  whoever drafts.
+  high-effort runs that hadn't written a file yet, and the bad rows made the engine look
+  worse than it was. Liveness tell: the `~/.codex/sessions` rollout file appears within
+  seconds; patience (15–30 min) applies only after it exists. **Slow is not failure.**
+- **`codex exec resume --last` picks whichever run finished most recently anywhere on
+  the machine** — with concurrent sessions, that's usually not your task. Resume by
+  session id.
+- **`codex exec review` errors when a prompt is combined with `--base`** (or any
+  diff-source flag) — review mode applies its own rubric; no focus prompt.
+- **The codex-companion runtime's per-worktree broker dies mid-run** in a multi-session,
+  restart-heavy workflow — it killed a 25-minute review that sat "running" forever.
+  Background work goes through `codex exec` only.
+- **Codex has auto-opened PRs and committed unprompted** — git stays with the driver,
+  and a supervisor that sees it happen resets the tree and says so.
 - **A vague brief costs more than it saves** — the fix rounds eat the delegation savings
   outright. Exact files, signatures, test cases, constraints, or write it inline.
-- **A read-only brief needs the driver to check it held** — nothing enforces read-only at
-  the tool layer for a general subagent. Eyeball `git status` after a verify walk; dirt
-  means the round was incomplete, not that the feature works.
+- **A read-only brief needs someone to check it held** — a plain `codex exec` has no
+  tool-enforced read-only. Eyeball `git status` after a walk; dirt means the round was
+  incomplete, not that the feature works.

--- a/plugins/ship/skills/verify/SKILL.md
+++ b/plugins/ship/skills/verify/SKILL.md
@@ -32,27 +32,32 @@ boots its own.
 provide a local/test way to reach authed surfaces. verify does **not** mint sessions, bypass
 auth, or stand up infra — that's repo plumbing, and baking it in here would couple this skill
 to one app. If authed surfaces are unreachable and the repo offers no test-auth path, the
-blessed alternative before `unverifiable`: **drive Pete's own Chrome over
-claude-in-chrome** — his real profile, already logged into everything, reached through
-the `mcp__claude-in-chrome__*` tools. Note in the verdict which route was used.
-Otherwise return `unverifiable` with the reason — never fake a pass.
+blessed alternative before `unverifiable`: **the logged-in codex Chrome** — a
+dedicated Chrome instance (profile `~/.codex/chrome-profile`, launch `~/.codex/codex-chrome`
+if `curl -s http://127.0.0.1:9222/json/version` says it's down) that the verifier's
+Playwright attaches to with `chromium.connectOverCDP("http://127.0.0.1:9222")`. Pete logs
+into each site there once; sessions persist. If the needed login exists only in Pete's
+*personal* Chrome, the last resort is a driver-side claude-in-chrome walk. Note in the
+verdict which route was used. Otherwise return `unverifiable` with the reason — never
+fake a pass.
 
 **The seeded account is the verifier's alone while a walk is in flight.** Never invite Pete
 to poke at the app on the same seeded user mid-round — his concurrent clicks read as bugs
 (a shared account once produced a false `broken` that cost a diagnosis round). Seed a second
-user for his hands-on look, or wait for the verdict. This applies doubly to
-claude-in-chrome, which drives his real profile and real tabs — a walk in flight owns
-the browser. Never leave a modal dialog open: an alert/confirm blocks every subsequent
-tool call and strands the run.
+user for his hands-on look, or wait for the verdict. This applies to the codex Chrome
+too (its logins are shared state) and doubly to claude-in-chrome, which drives his real
+profile and real tabs; Playwright's own isolated browser is immune by construction.
 
 ## 2. Verify the feature (delegate) → fix → re-verify (loop ≤ 3)
 
 Brief from the plan/spec file if one exists (point the verifier at it), else inline the
-acceptance criteria. The verifier is a **fresh subagent** — fresh so it judges the
-feature rather than its own work. It drives the running app over claude-in-chrome and
-captures screenshots as it goes. The brief must open with "READ-ONLY: edit no source
-files" — nothing enforces that at the tool layer, so the brief carries the constraint,
-and the driver eyeballs `git status` in the worktree after the run
+acceptance criteria. The verifier is a **fresh codex supervisor** — a subagent that
+owns one read-only codex walk (`codex-supervisor` skill: background, stall budget, read
+the result file, not scrollback). Fresh so it judges the feature rather than its own
+work. Codex scripts and runs its own Playwright against the running app and saves
+screenshots to real files. The brief must open with "READ-ONLY: edit no source files" —
+a plain `codex exec` has no tool-enforced read-only, so the brief carries the constraint,
+and the supervisor eyeballs `git status` in the worktree after the run
 (any dirt → discard it, count the round as `unverifiable`):
 
 ```
@@ -85,11 +90,12 @@ This report is your FINAL MESSAGE — it lands in the -o result file the caller 
 finishing without it is an incomplete run.
 ```
 
-**Auth-walled surface (the AUTH line forces it):** the verifier opens a new tab in
-Pete's own Chrome over claude-in-chrome — it is already logged in. Add to the brief:
-"call `tabs_context_mcp` first, then `tabs_create_mcp` for your own tab; never reuse a
-tab Pete is working in." If the site isn't logged in there, park with a `needs input:`
-asking Pete to log in once. **Last resort only** — the login exists solely in Pete's personal
+**Auth-walled surface (the AUTH line forces it):** point the walk at the **codex
+Chrome** instead of a fresh browser — add to the brief: "attach with
+`chromium.connectOverCDP('http://127.0.0.1:9222')` and drive a new tab there; it is
+logged in." (Launch `~/.codex/codex-chrome` first if :9222 is down; if the site isn't
+logged in there yet, park with a `needs input:` asking Pete to log in once — sessions
+persist after that.) **Last resort only** — the login exists solely in Pete's personal
 Chrome: a Claude subagent (`Agent(model: opus)`, unnamed one-shot, claude-in-chrome
 tools). Its screenshot reality: MCP screenshots render inline-only and the download
 fallback works ONCE per tab — save the one file early, use DOM measurements as


### PR DESCRIPTION
Correcting my over-read of "no more codex": Pete wanted it re-homed, not deleted.

**The shape:** the driver dispatches only to harness subagents and never runs `codex exec` itself. Closed-brief work goes to a **codex supervisor** — an Opus subagent that owns one codex session end to end (brief → launch → patience → fix rounds → verdict) and returns a result the driver can act on.

**Why it's better than either extreme.** Shelling out directly put codex's operational noise — polling, stall budgets, liveness tells, session ids, retries — straight into the driver's context. Deleting codex threw away the drafting leverage. The supervisor keeps the leverage and moves the noise into an agent that's cheap to spawn and cheap to discard.

**`router` → `codex-supervisor`.** Renamed because the job changed: it no longer routes between engines, it supervises one. Rewritten second-person to the subagent doing the work, with an explicit contract back to the driver — verdict, real file list, gates actually run, and what it didn't do. Never commits, never pushes, never widens scope.

**Escalation moved to where the evidence is.** "Two wrong diffs → escalate" is now the supervisor's call from inside the run, not the driver's guess from outside it. "Slow is not failure" is enforced in the same place.

Browser walks, correctness review, and DISCOVER recon all go back through codex under a supervisor. The one case that never reaches it: a login that exists solely in Pete's personal Chrome → driver-side claude-in-chrome.