### PR TITLE
Move the dispatch ledger off the retired router path

### DIFF
--- a/plugins/ship/skills/codex-supervisor/SKILL.md
+++ b/plugins/ship/skills/codex-supervisor/SKILL.md
@@ -113,9 +113,10 @@ Return `escalate` immediately, without burning rounds, when:
 
 ## The ledger
 
-Append one row per task to `~/.claude/skills/router/ledger.md` — the canonical ledger,
-kept outside any repo or plugin directory because an installed plugin isn't writable
-state:
+Append one row per task to `~/.claude/skills/codex-supervisor/ledger.md` — the canonical
+ledger, kept outside any repo or plugin directory because an installed plugin isn't
+writable state. (It lived at `~/.claude/skills/router/ledger.md` until 2026-08-12; the
+history moved with the rename rather than restarting.)
 
 `date | project | task (short) | task-type | engine | outcome | fix-rounds | note`
 


### PR DESCRIPTION
The ledger survived the `router` deletion by living outside the plugin, but it still sat in `~/.claude/skills/router/` — a directory for a skill that no longer exists, which is exactly how a file gets swept up by a later cleanup.

Moved to `~/.claude/skills/codex-supervisor/ledger.md` alongside the skill that writes it. History moved with it rather than restarting; the header now records the rename so the router-era rows (different engine mix) read correctly in context.

Caught by the `gstack ship migration` session reviewing #74 from its side — cross-session review working as intended.