### PR TITLE
Route ship's browser work through /browse

### DIFF
--- a/plugins/ship/skills/pipeline/SKILL.md
+++ b/plugins/ship/skills/pipeline/SKILL.md
@@ -101,7 +101,7 @@ a run killed early gets logged as a failure it didn't earn.
 Work smaller than a dispatch's ~5–10 min fixed overhead, the driver writes inline;
 skill/agent prose and design taste never route. **Codex draws coding drafts and nothing
 else** — recon, verify walks, design QA, and review fan-outs run on plain harness
-subagents (the Agent tool) with claude-in-chrome for anything in a browser. Never
+subagents (the Agent tool) with the `/browse` skill for anything in a browser. Never
 `claude -p` from inside a session. Never Sonnet.
 
 **The driver owns the envelope**, whoever drafts: it writes the brief the supervisor
@@ -111,8 +111,10 @@ committed (never trust a "tests pass" claim, from a supervisor or from codex), a
 git entirely. **One writer per branch at a time** — concurrent writers on one tree
 collide; serialize, or give each its own sub-worktree.
 
-**All browser work runs on claude-in-chrome** — verify walks, design QA, live-product
-grounding. A subagent drives the MCP browser tools against the running app and reports
+**All browser work runs on `/browse`** — verify walks, design QA, live-product
+grounding. Pete's standing rule: `/browse` for all web browsing, never the
+`mcp__claude-in-chrome__*` tools. Auth-walled surfaces get `/setup-browser-cookies`
+once; `/browse` keeps the session after that. A subagent drives the MCP browser tools against the running app and reports
 what it saw; browser work does not go to codex.
 
 **Never idle while a dispatch or subagent runs** — a codex draft, review, or QA pass
@@ -232,7 +234,7 @@ on main.
   replacement look routes through its `shape`/new-work path; a refinement stays on the
   incumbent world. Use `/pix` for imagery freely — the spec *is* the prototype.
   **Ground the design in the live product**: a subagent walks the running app /
-  deployed URL over claude-in-chrome and reports the real theme/CSS with screenshots;
+  deployed URL over `/browse` and reports the real theme/CSS with screenshots;
   design from those, never from in-repo mockups (incidents: Design).
 - **DISCOVER is a design workshop, not a handoff.** The first thing Pete sees is
   never a finished spec — it's a working session, opened the way a designer opens one:

--- a/plugins/ship/skills/verify/SKILL.md
+++ b/plugins/ship/skills/verify/SKILL.md
@@ -32,25 +32,26 @@ boots its own.
 provide a local/test way to reach authed surfaces. verify does **not** mint sessions, bypass
 auth, or stand up infra — that's repo plumbing, and baking it in here would couple this skill
 to one app. If authed surfaces are unreachable and the repo offers no test-auth path, the
-blessed alternative before `unverifiable`: **drive Pete's own Chrome over
-claude-in-chrome** — his real profile, already logged into everything, reached through
-the `mcp__claude-in-chrome__*` tools. Note in the verdict which route was used.
-Otherwise return `unverifiable` with the reason — never fake a pass.
+blessed alternative before `unverifiable`: **`/setup-browser-cookies`** — import the
+logged-in cookies into the `/browse` session, then walk it there. `/browse` persists
+cookies and login state between calls, so this is a one-time import per site. Note in
+the verdict which route was used. Otherwise return `unverifiable` with the reason —
+never fake a pass.
 
 **The seeded account is the verifier's alone while a walk is in flight.** Never invite Pete
 to poke at the app on the same seeded user mid-round — his concurrent clicks read as bugs
 (a shared account once produced a false `broken` that cost a diagnosis round). Seed a second
-user for his hands-on look, or wait for the verdict. This applies doubly to
-claude-in-chrome, which drives his real profile and real tabs — a walk in flight owns
-the browser. Never leave a modal dialog open: an alert/confirm blocks every subsequent
-tool call and strands the run.
+user for his hands-on look, or wait for the verdict. `/browse` is headless and
+isolated, so it never fights Pete for a tab — but its session state IS shared across
+calls, so two concurrent walks on one seeded account collide the same way.
 
 ## 2. Verify the feature (delegate) → fix → re-verify (loop ≤ 3)
 
 Brief from the plan/spec file if one exists (point the verifier at it), else inline the
 acceptance criteria. The verifier is a **fresh subagent** — fresh so it judges the
-feature rather than its own work. It drives the running app over claude-in-chrome and
-captures screenshots as it goes. The brief must open with "READ-ONLY: edit no source
+feature rather than its own work. It drives the running app through the **`/browse`
+skill** (Pete's standing rule: `/browse` for all web browsing, never the
+claude-in-chrome tools) and captures screenshots as it goes. The brief must open with "READ-ONLY: edit no source
 files" — nothing enforces that at the tool layer, so the brief carries the constraint,
 and the driver eyeballs `git status` in the worktree after the run
 (any dirt → discard it, count the round as `unverifiable`):
@@ -85,14 +86,12 @@ This report is your FINAL MESSAGE — it lands in the -o result file the caller 
 finishing without it is an incomplete run.
 ```
 
-**Auth-walled surface (the AUTH line forces it):** the verifier opens a new tab in
-Pete's own Chrome over claude-in-chrome — it is already logged in. Add to the brief:
-"call `tabs_context_mcp` first, then `tabs_create_mcp` for your own tab; never reuse a
-tab Pete is working in." If the site isn't logged in there, park with a `needs input:`
-asking Pete to log in once. **Last resort only** — the login exists solely in Pete's personal
-Chrome: a Claude subagent (`Agent(model: opus)`, unnamed one-shot, claude-in-chrome
-tools). Its screenshot reality: MCP screenshots render inline-only and the download
-fallback works ONCE per tab — save the one file early, use DOM measurements as
+**Auth-walled surface (the AUTH line forces it):** run **`/setup-browser-cookies`**
+once to import the logged-in cookies into the `/browse` session, then walk it normally —
+state persists across calls, so later rounds need no re-import. If the site defeats
+headless entirely (CAPTCHA, MFA, bot-fingerprinting), `/browse` has its own documented
+hand-off to a real browser; take that path and say so in the verdict. Park with a
+`needs input:` only when even the hand-off needs Pete's hands. Screenshot reality:
 storyboard substitutes for the rest (acceptable evidence). Note in the verdict which
 route was used.
 


### PR DESCRIPTION
ship told the pipeline to drive **claude-in-chrome** for verify walks, design QA, and live-product grounding. Pete's global CLAUDE.md says the opposite — `/browse` for all web browsing, never the claude-in-chrome tools — and he confirmed he's using `/browse` in practice.

Two live instructions in direct contradiction, both landed in ship today from two sessions that neither checked the global rule.

`/browse` is also the better fit: headless and isolated so a walk never fights Pete for a real tab, and it persists cookies/login state between calls. The auth-walled case that originally justified claude-in-chrome is covered by `/setup-browser-cookies` once per site, with `/browse`'s own hand-off for sites that defeat headless entirely (CAPTCHA/MFA/fingerprinting).

Also drops the claude-in-chrome screenshot workaround — inline-only renders and a download fallback that fires once per tab — a limitation of a tool we no longer use.