### PR TITLE
Supervisors announce the park, so silence is diagnosable

### DIFF
--- a/plugins/ship/skills/codex-supervisor/SKILL.md
+++ b/plugins/ship/skills/codex-supervisor/SKILL.md
@@ -37,6 +37,17 @@ silence as "still working."
   codex is up, never at the end.
 - **Going idle without a delivered verdict is a protocol violation.** If you notice
   you're idle and haven't sent one, send it immediately.
+- **Announce the park before you go quiet** (ship#85). Every time you're about to idle
+  on watchers, send one line first, so your silence describes itself:
+
+  ```
+  parked-on-watchers: pid <alive|gone> · phase=<drafting|fix-round-N|judging> · next=<what wakes you> · <one progress fact>
+  ```
+
+  Re-send it after any interim report that puts you back on watchers. **A bare idle
+  notification with no park line in front of it is the driver's anomaly signal** — a
+  healthy run must never fire it, and a dead one always will. This is the whole
+  liveness protocol: no polling, no heartbeat timer, one line per park.
 
 Return, in that message:
 

--- a/plugins/ship/skills/pipeline/SKILL.md
+++ b/plugins/ship/skills/pipeline/SKILL.md
@@ -354,6 +354,10 @@ on main.
   path at launch; if it goes silent, ping it once, then self-serve — read the result
   file, review the diff, run the gates yourself. Dead air on the *reporting* path has
   stalled a real ship twice in one run; the work was already done both times.
+- **Read the park line, don't ping on reflex.** A supervisor announces
+  `parked-on-watchers: …` before every idle. Idle *with* a park line = healthy, leave it
+  alone until the stall budget. A **bare** idle notification with no park line in front
+  of it is the anomaly worth chasing — that's the only ping.
 - **Single-writer vs fan-out — pick by the diff, not reflex.** Default one writer.
   Fan out writers (own worktrees, merged back) only for genuinely independent AND
   numerous tasks — a migration, a mechanical sweep. The high-value fan-out is the


### PR DESCRIPTION
Closes #85. A bare idle notification looks identical whether the supervisor
is healthily watching codex or dead — so the driver either pings (the noise
this layer exists to absorb) or ignores idles until the stall budget. One
line before every park fixes it: idle-with-park is healthy, bare idle is the
anomaly. No polling, no timer.
