### PR TITLE
Batch 24 ship-retro findings into the skills

### DIFF
--- a/plugins/ship/skills/codex-supervisor/SKILL.md
+++ b/plugins/ship/skills/codex-supervisor/SKILL.md
@@ -65,6 +65,12 @@ Hard limits, no exceptions:
 - **Never widen scope.** A neighbouring bug you spot goes in the verdict as a note. It
   does not go in the diff.
 - **Never touch a file outside the brief's stated set** without saying so explicitly.
+  Two carve-outs, both from burned runs: **test files whose assertions the planned change
+  invalidates are always in scope** (otherwise the run stops to ask and eats a resume
+  round-trip), and **your result file is never one of them** — the write-up goes to `-o`,
+  never into the repo. Codex has committed its own result doc before.
+- **Never run `git reset`, `git checkout`, or `git stash`.** One cleanup of a stray
+  worker commit ate a driver's unstaged edit.
 
 ## Launch
 
@@ -77,11 +83,24 @@ cd <repo> && codex exec -c model_reasoning_effort=high \
   forever — no session file, no error, no clue. This once ate a night of dispatches.
 - **`-o <result-file>` on every run** (e.g. `/tmp/ship-<task-slug>-result.md`). Read the
   file, never the scrollback — the result survives a truncated buffer or a missed exit.
+  **Exit 0 with no result file means the run did nothing** — `codex exec review` has
+  exited clean in seconds on an unrelated startup error. Empty file, empty verdict:
+  retry once, then report `failed`. Never let silence read as "nothing to report."
 - **No fast mode, effort high** (Pete, 2026-08-12). Don't pass `-c fast_mode=true`;
   dispatches take the config default (`fast_mode = false`).
 - **Always the sol variant** — leave the model unset to inherit `gpt-5.6-sol` from
   config; if it must be explicit, `-m gpt-5.6-sol`. Never plain `gpt-5.6`.
 - **cwd outside a git repo → `--skip-git-repo-check`**, or codex exits fatally.
+- **Dispatching into a linked worktree → add the primary `.git` to the writable roots**:
+  `-c sandbox_workspace_write.writable_roots='["<git-common-dir>"]'` (from
+  `git rev-parse --git-common-dir`). The worktree's index lives there, outside the
+  sandbox, so without it the run finishes green and then cannot commit — a real ship
+  stalled on exactly that.
+- **Auth can die mid-run.** `refresh_token_invalidated` in a dispatch means another
+  machine refreshed the same ChatGPT OAuth session: in-flight runs survive on their
+  access token, every new dispatch is instantly dead. Say so in your verdict immediately
+  — the driver builds inline while a human recovers with `codex logout && codex login
+  --device-auth`. Never sit retrying a dead engine.
 - **Tag the brief's first line**: `[ship-dispatch: <project> · <branch> · <task-slug>]`
   (append `-retryN` on redispatch). It rides in argv, so `ps aux | grep "codex exec"`
   attributes every run across Pete's concurrent sessions. Tell codex the tag is routing

--- a/plugins/ship/skills/pipeline/SKILL.md
+++ b/plugins/ship/skills/pipeline/SKILL.md
@@ -132,7 +132,10 @@ lands. Same posture at gates: notify, then keep doing non-gated work.
    follow the **html-effectiveness patterns** (https://thariqs.github.io/html-effectiveness/):
    plain-English TL;DR first, structure as diagrams/side-by-sides instead of prose,
    depth behind collapsibles, anything visual a *live* embed. Pattern picks are named
-   per stage.
+   per stage. **Prune hard inside that format — never reach for a new one.** Pete tried
+   landing-page-styled gate artifacts against the plain doc and kept the doc: "this is
+   taking it far too radical an approach… maybe there's just a little bit of pruning."
+   Cut any section that doesn't change a decision; shorter ledes, depth collapsed.
 2. **Two gates, at most.** GATE 1 = Pete's "go" on the pen design of record (DISCOVER runs as
    presented rounds, each a hard stop — see stage 1) — always gated on the GATED lane. GATE 2 = go (after PLAN, via the go-card) — a hard stop
    **only when the card carries a genuine call for Pete**: a PM tradeoff, a money path,
@@ -203,16 +206,25 @@ wt switch --create feature/<slug> --no-cd --format=json -y
 ```
 then enter the path from the JSON — Claude Code: `EnterWorktree({path})`; Codex:
 absolute paths. `--no-cd` is load-bearing. A `.config/wt.toml` auto-provisions
-gitignored runtime files. Write `printf 'discover' > <root>/.ship-stage`. Never build
-on main.
+gitignored runtime files. Write `printf 'discover' > <root>/.ship-stage`, then
+**`echo .ship-stage >> $(git rev-parse --git-common-dir)/info/exclude`** — `git add -A`
+sweeps the marker into commits otherwise (incidents: Worktrees). Never build on main.
 
 - **Provision the per-branch backend now** if the repo's ship contract has one — a
   worktree building against a shared backend clobbers it (incidents: Backends). No
-  preview lane → build against the repo's dev stack.
+  preview lane → build against the repo's dev stack. **Rewrite the worktree's env file
+  to the preview before the first backend command** and confirm the first deploy's host
+  is the preview: the inherited `.env.local` carries the shared key, and the
+  `--preview-name` flag does not override it (incidents: Backends). From here on the
+  preview's *name* comes from that file, never from the branch.
 - **Cross-repo case:** `EnterWorktree` only takes for the session's primary repo
   (incidents: Worktrees). Against any other repo, work the worktree by **absolute
   path** and **narrate the fork the moment you create it** (`forked feature/<slug> off
   main @ <path>`) — a blind status line must never make it look like nothing forked.
+- **Recon may contradict the fork — then re-fork.** In a multi-repo workspace the target
+  repo is itself a recon finding (incidents: Worktrees). Exit, `wt remove` the empty
+  worktree, fork in the right repo, narrate the move. Fork-first stays; being wrong
+  about the repo is cheap, being invisible is not.
 - **Opportunistic tidy:** glance at `git worktree list` and `wt remove <branch> -f`
   any worktree that provably landed (merged PR whose `headRefOid` matches its HEAD,
   clean tree — incidents: Worktrees). Never touch one with uncommitted work.
@@ -227,7 +239,10 @@ on main.
   nothing).
   The recon brief includes a **reuse audit**: for every core noun the feature
   introduces, grep the whole repo — data layer included — for existing infra before the
-  plan treats it as new (incidents: Design).
+  plan treats it as new (incidents: Design). When the design lands on an *existing*
+  surface, it also **classifies that surface's liveness** — current design system?
+  reachable from primary nav? touched by recent commits? — because a deprecated page
+  serves happily (incidents: Design). The spec names the chosen surface explicitly.
 - **Bug-shaped requests get an empirical root-cause check** — reproduce the failure or
   read the runtime evidence; never spec a fix from a hypothesis (incidents: Design).
 - **Consult the installed domain experts before you spec.** Recon tells you what the
@@ -309,6 +324,9 @@ on main.
   6. **Go → spec.** Produce the thin HTML spec: the scope contract wrapped around
      the pen exports (embed them) plus everything a comp can't carry — copy as
      data, routes, behavior, states, a11y. `open` it for the record; no re-gate.
+- **Commit every gate artifact to the branch before you fire the gate** (board, spec,
+  pen file, go-card). A parked ship with uncommitted work looks disposable to another
+  session's cleanup sweep, and one nearly lost its spec that way (incidents: Worktrees).
 - The spec lives in the repo's docs home (`specs/` or `docs/`, whichever it uses) —
   e.g. `specs/designs/YYYY-MM-DD-<slug>.html`. **The driver authors boards, briefs,
   and spec prose inline** (taste is the deliverable, never dispatched); pen authors
@@ -329,6 +347,9 @@ on main.
   not prose description) and plan to match it. Run `ponytail` as the *waste* critic,
   not a scope critic — it cuts reinvention and gold-plating, never specced scope. Save
   the markdown plan to the docs home (e.g. `specs/plans/YYYY-MM-DD-<slug>.md`).
+- **A task that computes from rows another code path writes gets one end-to-end test
+  through the real writer** — not just unit tests over hand-built rows, which pass while
+  the production writers produce garbage (incidents: Design).
 - **Consult a domain expert again only for a question the plan raises and the spec
   didn't settle** — schema shape, index or migration order, an API's real constraint,
   an auth boundary. Same rules as DISCOVER's consult: harness subagent, a question not
@@ -350,6 +371,10 @@ on main.
   each task to a `codex-supervisor` subagent — drafting goes to codex; sub-overhead
   work inline. The driver owns the brief, the diff review, the gates, and git. One
   writer per branch at a time.
+- **Standing brief boilerplate** (each line from a burned run — incidents: Dispatch):
+  test files whose assertions the planned change invalidates are **always in scope**,
+  allowlist or not; the result goes to the `-o` file and is **never committed**; the
+  worker never runs `git reset/checkout/stash`.
 - **A quiet supervisor never blocks the build.** Each one relays its `-o <result-file>`
   path at launch; if it goes silent, ping it once, then self-serve — read the result
   file, review the diff, run the gates yourself. Dead air on the *reporting* path has
@@ -373,15 +398,19 @@ on main.
   drive the spec's real user paths (the formal `verify` runs in REVIEW; don't invoke it
   twice). Two preconditions that have each cost a red deploy (incidents: Backends): a
   framework with its own production build → **run that build too**; the branch touched
-  `convex/` → **re-push the preview** (`npx convex deploy --preview-name <branch> -y`).
-  *You* find the breakage, never Pete.
+  `convex/` → **re-push the preview** (`npx convex deploy --preview-name <name-from-
+  .env.local> -y`, from the worktree root — the branch name and the shell's leftover cwd
+  have each sent a deploy to the wrong place). *You* find the breakage, never Pete.
 - Raise a hand only for a genuine fork (PM-framed, with a rec).
 
 ### 4 · REVIEW / MERGE — automatic  → marker: `review`, then remove the file
 
 - Write `review`. **Sync with main first**: `git fetch origin`; absorb upstream in the
   worktree (rebase, or merge if unsafe), re-run the gates, then dispatch review — and
-  re-sync right before the merge if main moved again (incidents: Worktrees).
+  re-sync right before the merge if main moved again (incidents: Worktrees). **If the
+  absorbed commits touched `convex/`, re-deploy the preview before any further
+  verification** — function skew is invisible to tsc, vitest and the production build,
+  and has hard-crashed a page after a green rebase (incidents: Backends).
 - **Freeze the tree while a verifier is driving** — no merges, rebases, or edits until
   its verdict lands (incidents: Worktrees). Absorb upstream *before* dispatching a
   round, never during.
@@ -391,7 +420,10 @@ on main.
   over-build sweep). The **driver triages every finding** — adversarial reviewers
   over-flag by design — fixes what's real, puts judgment calls on the card. Codex
   unavailable → `/code-review` + `ponytail-review` on the driver. The high-value
-  fan-out is here: several verifiers on one diff beats one.
+  fan-out is here: several verifiers on one diff beats one. **A missing or empty result
+  file means the review did not run** — it can exit 0 in seconds having done nothing.
+  Never read that as a clean bill: retry once, and if the retry is empty too, review on
+  the driver (incidents: Dispatch).
 - **Design QA for visual features** — a background supervisor first runs
   impeccable's deterministic detector over the branch's changed UI files
   (`node ~/.claude/skills/impeccable/scripts/detect.mjs --json <files>` — local, no
@@ -402,13 +434,21 @@ on main.
   depth, spacing, type, motion, states, copy, and the bans). The review card shows the
   pen-vs-built pairs — Pete reviews the design he iterated against the thing that got
   built. Bounded per impeccable's own ceiling: one batched round, one confirm, no
-  open-ended polish loops. Driver triages: real gaps fixed before the card, nits land
-  on the card for Pete.
+  open-ended polish loops. **Report only — the driver owns every fix**; check
+  `git status` the moment the round lands, because nothing enforces read-only at the
+  tool layer (incidents: Dispatch). Driver triages: real gaps fixed before the card,
+  nits land on the card for Pete.
 - **Put it in front of Pete, running.** For any visual/interactive feature, boot the
-  worktree's dev server in the background and `open http://localhost:<port>` so the
-  live local app is on his screen. **Never deploy to let him review; never tell him to
+  worktree's dev server **detached, never through a bounded pipe** (`nohup npm run dev >
+  dev.log 2>&1 &`, then curl-probe — a `| head -50` has SIGPIPE'd a server mid-verify)
+  and `open http://localhost:<port>` so the live local app is on his screen. A feature
+  behind an auth gate needs its secret in the worktree env, or localhost 403s and reads
+  as broken (incidents: Backends). **Never deploy to let him review; never tell him to
   "go look at the live site"** — the worktree's localhost is the review surface.
   (Non-UI change → show the demo/test output instead.)
+- **Screenshots live outside the repo** — the job tmp dir, never committed (~6MB of PNGs
+  broke a push); copy anything the presented card references somewhere durable before
+  teardown, or the card 404s its own proof (incidents: Worktrees).
 - **Prove it works — invoke `verify` before the card.** A fresh read-only supervisor
   drives the feature and returns `works | broken | unverifiable` + a
   screenshot storyboard; verify loops-to-fix (cap ~3). **`broken` after the cap, or
@@ -456,7 +496,9 @@ on main.
   auto-deploy → say so and hand the URL once up. Never make Pete run a deploy. Watch
   rules (each from a real incident — incidents: Backends): **watch the deploy to
   conclusion** (red = unfinished work, fix-forward on a new express branch); **watch
-  the run for YOUR commit**, not "latest," and artifact-check the lane; **a red shared
+  the run for YOUR commit** — `gh run list --commit $(git rev-parse <sha>)`, full SHA
+  only, a short one matches nothing and the watch times out silently — and
+  artifact-check the lane; **a red shared
   lane you didn't cause is a shared resource** — check for an existing fix PR, claim
   with a draft PR first.
 - **Promotion to production is NOT ship's job.** "Merged" means live on *dev*. Never

--- a/plugins/ship/skills/pipeline/reference/incidents.md
+++ b/plugins/ship/skills/pipeline/reference/incidents.md
@@ -10,6 +10,11 @@ These are facts, not process — the process lives in SKILL.md.
   session's *primary* repo. Against any other repo the cwd never moves and the status
   line stays blind — the worktree and `.ship-stage` are real but invisible. Work by
   absolute path and narrate the fork (see the narration contract).
+- **In a multi-repo workspace, the target repo is itself a recon finding.** A run forked
+  in the repo the conversation was about; recon then established the feature needed zero
+  changes there and landed entirely in a sibling repo. Fork-first stays (it's how Pete
+  sees engagement), but when recon contradicts the fork: exit, `wt remove` the empty
+  worktree, re-fork in the right repo, and narrate the move.
 - **`gh pr merge` run from inside the worktree fails** with `fatal: 'main' is already
   used by worktree …` — the PR merges on GitHub but local teardown never runs, stranding
   an orphan worktree. Merge from the main checkout, always.
@@ -31,6 +36,20 @@ These are facts, not process — the process lives in SKILL.md.
 - **Review against a stale fork reviews apparent reversions** of other ships' work —
   full review runs have been wasted. Sync with origin/main before dispatching review,
   and again before the merge.
+- **`git add -A` sweeps `.ship-stage` into commits.** The marker is untracked-but-present,
+  so busy build stages commit it; one reached a PR and would have put a stale `review`
+  marker on main, confusing the status line for every main-checkout session. Add it to
+  `.git/info/exclude` right after writing it — session-local state never belongs in the
+  repo's `.gitignore`.
+- **An uncommitted artifact in a parked worktree is unprotected.** A GATE 1 spec sat
+  uncommitted while the ship waited; a concurrent session's cleanup saw a branch with no
+  commits and swept the worktree. Commit gate artifacts to the branch *before* firing the
+  gate.
+- **Screenshots don't belong in the branch, and don't survive teardown.** ~6MB of verify
+  PNGs committed to a branch broke the push outright (sideband disconnect, branch had to
+  be rebuilt); storyboard images left in the worktree 404'd on the published review card
+  after `wt remove`. Keep them out of the repo (the job tmp dir), and copy anything a
+  presented card references somewhere durable before the merge.
 
 ## Backends & deploys
 
@@ -38,13 +57,51 @@ These are facts, not process — the process lives in SKILL.md.
   schema reconciles the shared plane to this branch and drops indexes other branches
   added. Per-branch preview backends exist for this; the shared dev deploy runs only
   from the main checkout.
+- **The inherited `.env.local` is a loaded gun, and `--preview-name` does NOT override
+  it.** `wt` reflinks the main checkout's env file into the worktree, carrying the SHARED
+  dev deploy key; a per-command `export` doesn't survive to the next command. A bare
+  `convex deploy` has landed on shared dev and reconciled it backward past six merged
+  PRs. After provisioning, rewrite the worktree's Convex trio (`CONVEX_DEPLOY_KEY`,
+  `NEXT_PUBLIC_CONVEX_URL`, `CONVEX_HTTP_URL`; drop `CONVEX_DEPLOYMENT`) before the first
+  convex command, and confirm the first deploy's output host is the preview.
+- **The preview's name is whatever provisioning slugified it to**, not the branch name.
+  `feature/desk-doorway` provisioned as `feature-desk-doorway`; passing the branch
+  verbatim silently created a SECOND preview, so deploys and seeds went to one backend
+  while the browser read another — three verification rounds burned. Read the name from
+  the worktree's `.env.local` (`CONVEX_DEPLOYMENT=preview:<name>`) and use that
+  everywhere; error loudly if it's absent.
 - **Convex previews hold stage-0 code and drift behind every `convex/` commit.**
-  Re-push before the smoke-walk: `npx convex deploy --preview-name <branch> -y`.
+  Re-push before the smoke-walk: `npx convex deploy --preview-name <name> -y`.
+- **Absorbing main can bring function skew the gates can't see.** A rebase pulled in a
+  new Convex function the branch's preview didn't have; tsc, vitest and `next build` were
+  all green and the page hard-crashed on the preview. After any sync whose diff touched
+  `convex/`, re-deploy the preview before further verification.
+- **A fresh verifier's unpinned CLI calls resolve to a different deployment than the app
+  serves** — its seeds landed on one backend while localhost read another, and it
+  reported the feature broken. Pin `--preview-name` / `--deployment` on every CLI call in
+  a verify brief.
+- **The Bash shell's cwd persists between calls.** A gates command ending in `cd flue`
+  sent the next `convex deploy` from that subdir; Convex scaffolded an untracked
+  `flue/convex/` and deployed ZERO functions over the preview backend. Anchor
+  cwd-sensitive commands with the worktree root explicitly.
+- **An auth-gated surface 403s on localhost when its secret lives only on the deployed
+  Workers** — the admin console rendered while every admin API route failed, and it read
+  as a broken feature (Pete reported "delete doesn't work"). Before presenting, put the
+  gate secret in the worktree's env, or say plainly which paths can't be exercised
+  locally.
 - **tsc + vitest green ≠ deployable.** Frameworks with their own production build
   (`next build`, `flue build`, wrangler/vite bundling) have failed on deploy after green
   tests. Run the production build in the smoke-walk.
+- **A dev server booted through a bounded pipe dies mid-verify.** `npm run dev 2>&1 |
+  head -50` got SIGPIPE'd the moment `head` exited; the verifier reported "localhost
+  refused connection" and a full round was wasted. Detach with output redirected to a
+  file (`nohup npm run dev > dev.log 2>&1 &`) and curl-probe before dispatching.
 - **A batch once merged 18 green PRs onto a dev lane that had been red for an hour.**
   A red deploy is unfinished work on every lane — watch to conclusion.
+- **`gh run list --commit` matches only the full 40-char SHA.** Armed with a short SHA
+  from `git log --oneline`, the deploy watch returned `[]` forever while the run existed
+  and succeeded — it timed out silently after 25 minutes. Use
+  `$(git rev-parse <short-sha>)`.
 - **Workflow concurrency can cancel your deploy run**; the superseding run's green reads
   as yours while the lane is mid-deploy. Watch the run for YOUR commit
   (`gh run list --commit <sha>`), and artifact-check the lane before handing back a URL.
@@ -62,20 +119,47 @@ These are facts, not process — the process lives in SKILL.md.
 - **A run once designed against a repo's old cream mockups while the live product had
   moved to a dark terminal UI** — caught at GATE 1, whole spec redone. The running app is
   the design source of truth, never in-repo mockups.
+- **A deprecated page serves happily.** A feature was designed, approved and built onto a
+  public route the repo had abandoned; Pete caught it mid-REVIEW and the work had to move.
+  "Grounded in the live product" proves a surface *renders*, not that it's *current* —
+  classify liveness (on the current design system? reachable from primary nav? touched by
+  recent commits?) and name the chosen surface explicitly in the spec.
+- **Idealized-input tests hide writer/reader contract drift.** Unit tests over hand-built
+  rows passed while the real ledger writers produced garbage for two of three metrics
+  (one always 100%, one always null); only the adversarial review caught it. A task that
+  computes from rows another code path writes needs at least one case through the real
+  writer.
 
 ## Dispatch
-
-(Codex was retired from the pipeline on 2026-08-10; its CLI-specific incidents went with
-it. These are the lessons that outlived the engine.)
 
 - **Runs killed at a 2-minute timeout got mislogged as failures** — they were healthy
   high-effort runs that hadn't written anything yet. **Slow is not failure.** Give a
   dispatch a generous window and check in rather than killing; escalate on a wrong diff,
   never on a slow one.
 - **A worker has auto-opened PRs and committed unprompted** — git stays with the driver,
-  whoever drafts.
+  whoever drafts. One also committed its own result markdown into the repo, and a `--hard`
+  reset cleaning that up ate an unstaged driver edit: results go to the `-o` file, and
+  workers never run `git reset/checkout/stash`.
 - **A vague brief costs more than it saves** — the fix rounds eat the delegation savings
   outright. Exact files, signatures, test cases, constraints, or write it inline.
 - **A read-only brief needs the driver to check it held** — nothing enforces read-only at
-  the tool layer for a general subagent. Eyeball `git status` after a verify walk; dirt
-  means the round was incomplete, not that the feature works.
+  the tool layer for a general subagent. A design-QA round briefed as judge-only applied
+  its own fixes to a tree the driver believed was frozen. Eyeball `git status` after any
+  verify or QA walk; dirt means the round was incomplete, not that the feature works.
+- **A touch-only file allowlist collides with "whole suite green"** whenever the planned
+  behavior change invalidates an assertion in a test file outside the list — two of three
+  dispatches stopped mid-run to ask permission, each costing a resume round-trip. Briefs
+  say so up front: test files whose assertions the change invalidates are always in scope.
+- **`codex exec review` can exit 0 in seconds without writing its result file** (it hit an
+  unrelated skill-loading error and stopped). A missing or empty result file means the
+  review DID NOT RUN — never a clean bill. A plain retry of the identical command then
+  produced five genuine findings, two of them serious.
+- **codex's workspace-write sandbox can't commit from a linked worktree** — the index
+  lives under the primary repo's `.git`, outside the sandbox root. Add the common git dir
+  (`git rev-parse --git-common-dir`) to `sandbox_workspace_write.writable_roots`.
+- **codex's ChatGPT auth can die mid-BUILD.** A second machine refreshing the same OAuth
+  session invalidated it (`refresh_token_invalidated`); in-flight runs survived on their
+  access token while every new dispatch was instantly dead. Recover with
+  `codex logout && codex login --device-auth` (approve the code at
+  `auth.openai.com/codex/device` — fill the segmented boxes with `form_input`, synthetic
+  keystrokes get eaten); build inline meanwhile rather than parking the ship.

--- a/plugins/ship/skills/verify/SKILL.md
+++ b/plugins/ship/skills/verify/SKILL.md
@@ -71,6 +71,11 @@ AUTH (if behind login):
   <the repo's local/test-auth path, or 'none'>. Use ONLY that path. Do NOT mint sessions, set
   auth cookies, log in through the real login UI, or hit a dev-login endpoint yourself. If it's
   'none' or the path fails, return `unverifiable` and stop — never improvise a way past auth.
+BACKEND (repos with per-branch/preview backends):
+  <the exact deployment the app is serving>. Pin it on EVERY CLI call
+  (--preview-name/--deployment). Unpinned calls resolve to a different deployment than the
+  app reads, so your seeds land on one backend and the browser on another — that split-brain
+  reports as a broken feature and burns the whole round.
 
 Drive the REAL flow with Playwright — walk the exact steps a user would, like clicking through
 it. Screenshot the MEANINGFUL BEATS (start → action → success), not a random dump. Judge


### PR DESCRIPTION
Most are environment facts, so they land in incidents.md where they're read
on demand rather than bloating the driver's context; only the ones that must
change a decision at a specific stage got a line in SKILL.md.

Preview-backend identity (the inherited env file, the slugified name, skew
after a rebase, pinning identifiers in verify briefs, cwd drift), .ship-stage
riding git add -A into main, uncommitted gate artifacts swept by another
session, screenshots that break pushes or die with the worktree, short SHAs
that make the deploy watch a no-op, dev servers SIGPIPE'd by a bounded pipe,
auth-gated surfaces that 403 on localhost, deprecated-but-serving pages,
idealized-input tests that miss writer drift, and the multi-repo case where
recon contradicts the fork.

Plus three codex facts that came back to life when dispatch was restored on
08-12: review can exit 0 without writing a result file (a run could merge
unreviewed), worktree builds need the primary .git as a writable root, and
mid-build auth death has a known recovery.

Closes #37 #38 #39 #40 #41 #42 #43 #44 #45 #47 #48 #49 #51 #52 #53 #55 #56
#59 #60 #61 #62 #63 #64
