### PR TITLE
Entering the worktree is mandatory, and browsing splits by wall

### DIFF
--- a/plugins/ship/skills/pipeline/SKILL.md
+++ b/plugins/ship/skills/pipeline/SKILL.md
@@ -112,11 +112,12 @@ committed (never trust a "tests pass" claim, from a supervisor or from codex), a
 git entirely. **One writer per branch at a time** — concurrent writers on one tree
 collide; serialize, or give each its own sub-worktree.
 
-**All browser work runs on `/browse`** — verify walks, design QA, live-product
-grounding. Pete's standing rule: `/browse` for all web browsing, never the
-`mcp__claude-in-chrome__*` tools. Auth-walled surfaces get `/setup-browser-cookies`
-once; `/browse` keeps the session after that. A subagent drives the MCP browser tools against the running app and reports
-what it saw; browser work does not go to codex.
+**Browser work splits by wall** (Pete's standing rule): plain headless QA and
+unauthenticated browsing — verify walks, design QA, live-product grounding — run on
+**`/browse`**; **auth-walled or bot-walled surfaces run on `pane`** (open a tab as your
+agent name, raise a handoff when a human is genuinely needed). Never the
+`mcp__claude-in-chrome__*` tools. A subagent drives the browser against the running app
+and reports what it saw; browser work does not go to codex.
 
 **Never idle while a dispatch or subagent runs** — a codex draft, review, or QA pass
 is 10–25 minutes.
@@ -204,8 +205,14 @@ base branch.
 ```
 wt switch --create feature/<slug> --no-cd --format=json -y
 ```
-then enter the path from the JSON — Claude Code: `EnterWorktree({path})`; Codex:
-absolute paths. `--no-cd` is load-bearing. A `.config/wt.toml` auto-provisions
+then enter the path from the JSON. **In the session's primary repo, `EnterWorktree({path})`
+is MANDATORY, not a suggestion** — the status line and FleetView read the session's cwd,
+so a run that keeps working by absolute path while parked on main is invisible to Pete
+even though `.ship-stage` is being written faithfully in the worktree (he has had to ask
+mid-BUILD whether a run forked at all). Absolute-path driving is the *cross-repo*
+fallback only, where `EnterWorktree` can't take. **Self-heal:** notice mid-pipeline that
+the session cwd isn't the worktree → `EnterWorktree({path})` right then; it works fine
+after the fact. Codex Desktop: absolute paths throughout. `--no-cd` is load-bearing. A `.config/wt.toml` auto-provisions
 gitignored runtime files. Write `printf 'discover' > <root>/.ship-stage`, then
 **`echo .ship-stage >> $(git rev-parse --git-common-dir)/info/exclude`** — `git add -A`
 sweeps the marker into commits otherwise (incidents: Worktrees). Never build on main.

--- a/plugins/ship/skills/verify/SKILL.md
+++ b/plugins/ship/skills/verify/SKILL.md
@@ -32,9 +32,9 @@ boots its own.
 provide a local/test way to reach authed surfaces. verify does **not** mint sessions, bypass
 auth, or stand up infra — that's repo plumbing, and baking it in here would couple this skill
 to one app. If authed surfaces are unreachable and the repo offers no test-auth path, the
-blessed alternative before `unverifiable`: **`/setup-browser-cookies`** — import the
-logged-in cookies into the `/browse` session, then walk it there. `/browse` persists
-cookies and login state between calls, so this is a one-time import per site. Note in
+blessed alternative before `unverifiable`: walk it in **`pane`**, which owns auth-walled
+and bot-walled surfaces (open a tab as your agent name; it keeps the logged-in session
+between calls and raises a handoff when a human is genuinely needed). Note in
 the verdict which route was used. Otherwise return `unverifiable` with the reason —
 never fake a pass.
 
@@ -50,8 +50,8 @@ calls, so two concurrent walks on one seeded account collide the same way.
 Brief from the plan/spec file if one exists (point the verifier at it), else inline the
 acceptance criteria. The verifier is a **fresh subagent** — fresh so it judges the
 feature rather than its own work. It drives the running app through the **`/browse`
-skill** (Pete's standing rule: `/browse` for all web browsing, never the
-claude-in-chrome tools) and captures screenshots as it goes. The brief must open with "READ-ONLY: edit no source
+skill** (Pete's standing rule: `/browse` for plain headless browsing, `pane` for
+auth-walled surfaces, never the claude-in-chrome tools) and captures screenshots as it goes. The brief must open with "READ-ONLY: edit no source
 files" — nothing enforces that at the tool layer, so the brief carries the constraint,
 and the driver eyeballs `git status` in the worktree after the run
 (any dirt → discard it, count the round as `unverifiable`):
@@ -91,12 +91,11 @@ This report is your FINAL MESSAGE — it lands in the -o result file the caller 
 finishing without it is an incomplete run.
 ```
 
-**Auth-walled surface (the AUTH line forces it):** run **`/setup-browser-cookies`**
-once to import the logged-in cookies into the `/browse` session, then walk it normally —
-state persists across calls, so later rounds need no re-import. If the site defeats
-headless entirely (CAPTCHA, MFA, bot-fingerprinting), `/browse` has its own documented
-hand-off to a real browser; take that path and say so in the verdict. Park with a
-`needs input:` only when even the hand-off needs Pete's hands. Screenshot reality:
+**Auth-walled surface (the AUTH line forces it):** walk it in **`pane`**, not
+`/browse` — pane is the standing route for anything credentialed or bot-walled, holds
+the logged-in session across calls, and raises a handoff when the wall (CAPTCHA, MFA,
+fingerprinting) genuinely needs a human. Say in the verdict which route was used. Park
+with a `needs input:` only when even that handoff needs Pete's hands. Screenshot reality:
 storyboard substitutes for the rest (acceptable evidence). Note in the verdict which
 route was used.
 


### PR DESCRIPTION
Two drifts. First: stage 0 said 'then enter the path' softly while the
cross-repo section legitimizes absolute-path driving, so a live run worked
its worktree by path, never entered it, and vanished from Pete's status
line mid-BUILD — he had to ask whether it had forked at all. Entering is now
mandatory in the primary repo, with a self-heal for noticing late.

Second: Pete's standing browser rule now splits — auth-walled and bot-walled
surfaces go to pane, plain headless QA stays on /browse. The skills still
sent everything to /browse with a cookie import.
