### PR TITLE
Retire the obsolete router vocabulary

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,12 +5,12 @@
     "email": "petefromsf@gmail.com"
   },
   "metadata": {
-    "description": "/ship — take a feature from idea to merged in one command. Two gates, auto-opening cards, gate notifications, a stage-aware status line, model-routed build, and fresh-agent verification."
+    "description": "/ship — take a feature from idea to merged in one command. Two gates, auto-opening cards, gate notifications, a stage-aware status line, supervised builds, and fresh-agent verification."
   },
   "plugins": [
     {
       "name": "ship",
-      "description": "/ship — idea to merged in one command: worktree → discover → plan → build → review, gating only on design direction and 'go'. Auto-opening HTML cards, gate desktop notifications, a stage-aware status line, BUILD routing across Opus and GPT-5.5, and fresh-agent verification. Bundles router + verify.",
+      "description": "/ship — idea to merged in one command: worktree → discover → plan → build → review, gating only on design direction and 'go'. Auto-opening HTML cards, gate desktop notifications, a stage-aware status line, supervised codex builds, and fresh-agent verification. Bundles codex-supervisor + verify.",
       "source": "./plugins/ship"
     }
   ]

--- a/plugins/ship/skills/codex-supervisor/SKILL.md
+++ b/plugins/ship/skills/codex-supervisor/SKILL.md
@@ -184,8 +184,7 @@ Return `escalate` immediately, without burning rounds, when:
 
 Append one row per task to `~/.claude/skills/codex-supervisor/ledger.md` — the canonical
 ledger, kept outside any repo or plugin directory because an installed plugin isn't
-writable state. (It lived at `~/.claude/skills/router/ledger.md` until 2026-08-12; the
-history moved with the rename rather than restarting.)
+writable state.
 
 `date | project | task (short) | task-type | engine | outcome | fix-rounds | note`
 

--- a/plugins/ship/skills/pipeline/design/2026-06-29-ship-pipeline.html
+++ b/plugins/ship/skills/pipeline/design/2026-06-29-ship-pipeline.html
@@ -134,7 +134,7 @@
     </div>
     <div class="stage">
       <div class="l"><span class="n glyph">🔨 4</span><b>Build</b><span class="tag auto">auto</span></div>
-      <div class="r">subagent-driven-development, driven by <strong>Opus</strong>, which <strong>routes each build task ~50/50 to Opus or GPT-5.5</strong> (the <code>router</code> skill — judgment/integration/risk → Opus, well-specified self-contained coding → GPT-5.5 via codex). + <strong>ponytail posture</strong> (shortest diff, reuse, no reinventing the wheel) + <strong>verification-before-completion</strong> (actually runs it) + <strong>systematic-debugging</strong> on any failure. Can raise its hand for a real fork; you can jump in anytime from FleetView.</div>
+      <div class="r">Each build task has one <strong>Opus supervisor</strong> for one codex session. + <strong>ponytail posture</strong> (shortest diff, reuse, no reinventing the wheel) + <strong>verification-before-completion</strong> (actually runs it) + <strong>systematic-debugging</strong> on any failure. Can raise its hand for a real fork; you can jump in anytime from FleetView.</div>
     </div>
     <div class="stage">
       <div class="l"><span class="n glyph">👀 5</span><b>Review / merge</b><span class="tag auto">auto</span></div>
@@ -182,7 +182,7 @@
     <tr><td>impeccable</td><td>Discover — HTML design sprint (pix imagery). Skipped for non-visual features. <code>init</code> already done for homezero.</td></tr>
     <tr><td>writing-plans</td><td>Plan — the implementation plan (HTML artifact).</td></tr>
     <tr><td>ponytail ×2</td><td>Plan (scope critic, primary) + Build (posture). The cut-list rides onto the go-card.</td></tr>
-    <tr><td>router</td><td>Build only — Opus driver splits each build task ~50/50 Opus ↔ GPT-5.5 (codex). Two engines, no Sonnet/Gemini. Self-tunes via a ledger. <em>Never fires outside Build.</em></td></tr>
+    <tr><td>codex-supervisor</td><td>Build only — one Opus subagent supervises one codex session and returns the verified diff to the driver.</td></tr>
     <tr><td>verification-before-completion</td><td>Build→Review — the agent runs the thing and watches it work before claiming done. <em>The trust guard.</em></td></tr>
     <tr><td>systematic-debugging</td><td>Build — the failure fallback when a test goes red.</td></tr>
     <tr><td>/code-review + ponytail-review</td><td>Review — correctness + over-build, one automated pass.</td></tr>
@@ -208,7 +208,7 @@
   <table class="ledger">
     <tr><td>Gating model</td><td>Two gates — design direction, then go. Spec/plan never gate. Scales out for non-visual features.</td></tr>
     <tr><td>Ponytail placement</td><td>Both — scope critic at Plan (primary), posture at Build.</td></tr>
-    <tr><td>Model routing</td><td>Build-only. Opus driver, ~50/50 Opus ↔ GPT-5.5. Router rewritten to two engines (Sonnet/Gemini cut). Opus owns brief/review/gates/git; one writer per branch.</td></tr>
+    <tr><td>Build ownership</td><td>One Opus supervisor owns one codex session; the driver owns review, gates, and git; one writer per branch.</td></tr>
     <tr><td>Persona</td><td>Technical PM, not engineer. Guide + recommend; taste leads.</td></tr>
     <tr><td>Library threshold</td><td>Standing stack never re-asked; escalate only architectural + outside-canon.</td></tr>
     <tr><td>Shape</td><td>Design up front (interleaved with brainstorm); spec is Discover's artifact, not a stage.</td></tr>


### PR DESCRIPTION
The shipped workflow already uses codex-supervisor. Removing the old router name keeps fresh installs aligned with the live pipeline and avoids reviving the retired skill.
