### PR TITLE
Every codex run is an app-server thread, and a repo can say what it is

### DIFF
--- a/plugins/ship/skills/codex-supervisor/SKILL.md
+++ b/plugins/ship/skills/codex-supervisor/SKILL.md
@@ -1,25 +1,33 @@
 ---
 name: codex-supervisor
-description: Use when you are a subagent that has been handed one codex coding task to manage — a /ship BUILD drafting task. You own that codex session end to end: brief, launch, keeping it alive, fix rounds, verdict. The driver never runs codex directly; it dispatches you and you run codex. Do NOT invoke this on the driver, do NOT invoke it for work that should be written inline, and do NOT use it for browser walks, recon, or review — those run on plain harness subagents.
+description: Use when you are a subagent that has been handed one codex coding task to manage — a /ship BUILD drafting task, or a REVIEW pass. You own that codex session end to end: brief, launch, watching it, fix rounds, verdict. The driver never runs codex directly; it dispatches you and you run codex through scripts/dispatch.mjs on codex app-server. Do NOT invoke this on the driver, do NOT invoke it for work that should be written inline, and do NOT use it for browser walks or recon — those run on plain harness subagents.
 ---
 
 # codex-supervisor — one subagent owns one codex session
 
 **You are the supervisor, not the author.** The driver handed you exactly one coding
 task and then stopped thinking about it. Codex draws the draft; you keep it alive, judge
-it, and carry the result back. You author the brief, launch codex, wait it out, judge
+it, and carry the result back. You author the brief, launch the run, wait it out, judge
 what comes back, run the fix rounds, and return a verdict the driver can act on without
 reading a line of your scrollback.
 
 **Why this shape** (Pete, 2026-08-10): codex tokens buy drafts, driver tokens buy
-judgment — and the *watching* is neither. Polling, stall checks, liveness tells, retries,
-a session id that has to be threaded through three commands: that noise used to land in
-the driver's context and crowd out the work. Now it lands in yours. You are cheap to
-spawn and cheap to throw away; the driver's context is the scarce thing.
+judgment — and the *watching* is neither. Polling, stall checks, liveness tells, retries:
+that noise used to land in the driver's context and crowd out the work. Now it lands in
+yours. You are cheap to spawn and cheap to throw away; the driver's context is the scarce
+thing.
 
 **You run on Opus.** You are judging a diff and deciding whether to press on or hand
 back — that is the judgment half of the job, and it is why a subagent supervises rather
 than a bare shell command.
+
+**Every run is `codex app-server`, never `codex exec`** (Pete, 2026-09-03). An exec run
+that went dark — a held stdin, a startup error, a model that stopped calling tools —
+looked exactly like a slow one from outside, and a whole ship once waited an hour on a
+run that had died at startup. `scripts/dispatch.mjs` owns the app-server process and
+makes the run legible while it runs: every event with a clock, a status file that says
+what codex did last and how long ago, a watchdog that interrupts a silent turn and says
+so in its exit code. You read files, never scrollback, and you never wonder.
 
 ## Your contract with the driver
 
@@ -32,16 +40,17 @@ silence as "still working."
   before you idle or finish. Not a summary, not "done" — the full four-part contract
   below, in one message.
 - **Relay the dispatch contract at launch, before any waiting**: one short SendMessage
-  with the `-o <result-file>` path, the session id, and the task slug. If you die, stall,
-  or sleep through the landing, the driver can self-serve the result. Do this the moment
-  codex is up, never at the end.
+  with the `--result` path, the `--log` directory, the thread id, and the task slug. If
+  you die, stall, or sleep through the landing, the driver can self-serve the result
+  (`dispatch.mjs status --log <dir>` says everything). Do this the moment the thread id
+  is in `status.json`, never at the end.
 - **Going idle without a delivered verdict is a protocol violation.** If you notice
   you're idle and haven't sent one, send it immediately.
 - **Announce the park before you go quiet** (ship#85). Every time you're about to idle
   on watchers, send one line first, so your silence describes itself:
 
   ```
-  parked-on-watchers: pid <alive|gone> · phase=<drafting|fix-round-N|judging> · next=<what wakes you> · <one progress fact>
+  parked-on-watchers: pid <alive|gone> · phase=<drafting|fix-round-N|judging> · next=<what wakes you> · <one progress fact from status.json>
   ```
 
   Re-send it after any interim report that puts you back on watchers. **A bare idle
@@ -67,104 +76,119 @@ Hard limits, no exceptions:
 - **Never touch a file outside the brief's stated set** without saying so explicitly.
   Two carve-outs, both from burned runs: **test files whose assertions the planned change
   invalidates are always in scope** (otherwise the run stops to ask and eats a resume
-  round-trip), and **your result file is never one of them** — the write-up goes to `-o`,
-  never into the repo. Codex has committed its own result doc before.
+  round-trip), and **your result file is never one of them** — the write-up goes to
+  `--result`, never into the repo. Codex has committed its own result doc before.
 - **Never run `git reset`, `git checkout`, or `git stash`.** One cleanup of a stray
   worker commit ate a driver's unstaged edit.
 
 ## Launch
 
+Write the brief to a file, then:
+
 ```
-cd <repo> && codex exec -c model_reasoning_effort=high \
-  -o <result-file> "<full task brief>" < /dev/null
+node ~/.claude/plugins/cache/ship/ship/*/skills/codex-supervisor/scripts/dispatch.mjs run \
+  --cwd <repo or worktree> --brief <brief-file> \
+  --result <log-dir>/result.md --log <log-dir> \
+  --tag "ship-dispatch: <project> · <branch> · <task-slug>"
 ```
 
-- **`< /dev/null` is mandatory.** A held-open stdin hangs `codex exec` at startup
-  forever — no session file, no error, no clue. This once ate a night of dispatches.
-- **`-o <result-file>` on every run** (e.g. `/tmp/ship-<task-slug>-result.md`). Read the
-  file, never the scrollback — the result survives a truncated buffer or a missed exit.
-  **Exit 0 with no result file means the run did nothing** — `codex exec review` has
-  exited clean in seconds on an unrelated startup error. Empty file, empty verdict:
-  retry once, then report `failed`. Never let silence read as "nothing to report."
-- **No fast mode, effort high** (Pete, 2026-08-12). Don't pass `-c fast_mode=true`;
-  dispatches take the config default (`fast_mode = false`).
-- **Always the sol variant** — leave the model unset to inherit `gpt-5.6-sol` from
-  config; if it must be explicit, `-m gpt-5.6-sol`. Never plain `gpt-5.6`.
-- **cwd outside a git repo → `--skip-git-repo-check`**, or codex exits fatally.
-- **Dispatching into a linked worktree → add the primary `.git` to the writable roots**:
-  `-c sandbox_workspace_write.writable_roots='["<git-common-dir>"]'` (from
-  `git rev-parse --git-common-dir`). The worktree's index lives there, outside the
-  sandbox, so without it the run finishes green and then cannot commit — a real ship
-  stalled on exactly that.
-- **Auth can die mid-run.** `refresh_token_invalidated` in a dispatch means another
-  machine refreshed the same ChatGPT OAuth session: in-flight runs survive on their
-  access token, every new dispatch is instantly dead. Say so in your verdict immediately
-  — the driver builds inline while a human recovers with `codex logout && codex login
-  --device-auth`. Never sit retrying a dead engine.
-- **Tag the brief's first line**: `[ship-dispatch: <project> · <branch> · <task-slug>]`
-  (append `-retryN` on redispatch). It rides in argv, so `ps aux | grep "codex exec"`
-  attributes every run across Pete's concurrent sessions. Tell codex the tag is routing
-  metadata to ignore.
-- **Dispatch with `run_in_background`**, never a hand-rolled `&`.
-- **Billing sanity-check on first use**: codex bills the ChatGPT subscription only on its
-  *subscription* login. An `OPENAI_API_KEY` in the env silently bills per call. Check:
-  `codex login status` says "Logged in using ChatGPT" and `~/.codex/auth.json` has
-  `auth_mode: chatgpt`; `echo ${OPENAI_API_KEY:-unset}` must print `unset`. If a key is
-  in the env, launch under `env -u OPENAI_API_KEY -u OPENAI_BASE_URL`.
+(`$CLAUDE_PLUGIN_ROOT/skills/codex-supervisor/scripts/dispatch.mjs` when the variable is
+set; the glob is the installed cache.) Use a `<log-dir>` under the job's tmp directory,
+one per dispatch, e.g. `$CLAUDE_JOB_DIR/tmp/ship-<task-slug>/`.
 
-**Never the codex-companion runtime for background work** — its per-worktree broker
-daemon dies mid-run in a multi-session workflow and the job orphans "running" forever.
-Companion is for short foreground calls only.
+- **Dispatch with `run_in_background`**, never a hand-rolled `&`. The background job's
+  exit notification is your landing signal; its last stdout line is one JSON object
+  (`outcome`, `exitCode`, `threadId`, `result`, `log`, `counts`).
+- **The model and effort are pinned in the script**: `gpt-5.6-sol` at `high`, on every
+  run. Never lower the effort to go faster; never pass `--model` for anything else. The
+  script strips `OPENAI_API_KEY` and `OPENAI_BASE_URL` from the child's environment, so
+  a run bills the ChatGPT subscription; check once per machine that `codex login status`
+  says "Logged in using ChatGPT".
+- **Worktrees need nothing extra.** The script adds the repo's git common dir to the
+  writable roots itself (a linked worktree's index lives under the primary `.git`,
+  outside the sandbox, and a worker that cannot `git add` stops to ask). Pass
+  `--writable-root <dir>` for anything else the brief needs written outside the tree.
+- **Exit codes are the verdict's first word**: `0` completed · `2` the turn failed
+  (codex's message is in the result file, with its `codexErrorInfo`: a usage limit,
+  an auth failure, a context window) · `3` stalled and interrupted at `--stall-min`
+  (default 15) · `4` the hard `--timeout-min` cap (default 120) · `5` app-server died
+  or never started (stderr tail in the result) · `6` you called it wrong.
+- **The result file is written last, on every path.** A completed run's result is the
+  final agent message; anything else starts `DISPATCH <OUTCOME>:` and carries the last
+  agent message and stderr tail. An empty result with exit 0 means the model finished
+  without a final message: read `transcript.md` before judging.
+- **Tag the brief** with `[ship-dispatch: <project> · <branch> · <task-slug>]` on its
+  first line too, and tell codex the tag is routing metadata to ignore; `status.json`
+  carries `--tag`, so a driver looking at three log dirs knows whose is whose.
+- **Standing brief boilerplate** (each line from a burned run): test files whose
+  assertions the planned change invalidates are always in scope; the write-up is the
+  final message, never a file in the repo; never `git reset/checkout/stash`; never
+  commit or push.
 
-## Keeping the session alive — your headline duty
+## Watching — your headline duty, and now a file
 
 A high-effort worker sits quiet for many minutes. Runs killed at a two-minute timeout
 were healthy and got logged as failures, which then made the engine look worse than it
-was. **Slow is not failure.** Give it 15–30 minutes and check in rather than killing.
-Never drop effort to go faster.
+was. **Slow is not failure.** The difference between slow and dead is now written down:
 
-- **Arm a `Monitor` on the rollout file instead of blind-polling.** Codex narrates every
-  step into its session JSONL, so its progress lands in your chat as it happens. Right
-  after launch (the newest rollout file is your run — capture it once, it's also the
-  session id you resume by):
+```
+node <...>/dispatch.mjs status --log <log-dir>
+```
 
-  ```
-  S=$(ls -t ~/.codex/sessions/*/*/*/*.jsonl | head -1)
-  ```
+prints `status.json` with `phase`, `lastEvent`, `idleSeconds`, `elapsedSeconds`,
+`counts` (items, commands, file changes, agent messages, server requests),
+`lastCommand`, `lastAgentMessage`, `tokenUsage`, and `alive` (is the pid there). A
+run with `idleSeconds` climbing and `alive: true` is thinking or running a long command
+(`lastCommand` says which); a run with `alive: false` and no `outcome` line is the
+anomaly, and `stderr.log` is where it explains itself.
 
-  then `Monitor` with `persistent: true` and:
-
-  ```
-  tail -f -n0 "$S" | jq -r --unbuffered 'select(.payload.type|IN("agent_message","patch_apply_end","task_complete","error","stream_error","turn_aborted")) | .payload | "[\(.type)] \(((.message // .stdout // .last_agent_message // "") | tostring | split("\n")[0])[0:150])"'
-  ```
-
-  The background job's own exit notification covers death/completion; the monitor covers
-  mid-flight. `TaskStop` it when you write the verdict.
-- **The landing trigger is state, not a notification: process gone + result file on
-  disk = judge and report NOW.** A supervisor once sat parked waiting on a completion
-  notification that never fired while the finished result sat unread and the whole ship
-  stalled. Never wait on a notification you can check for yourself.
-- **Startup liveness tell:** a healthy `codex exec` writes its `~/.codex/sessions`
-  rollout file within seconds. Process alive but no session file after ~2 min = dead at
-  startup (held stdin, bad flag). Kill and redispatch. This is the *only* early kill.
-- **Stall budget: ~15 min of silence → an active look.** Is the process in `ps`? Is the
-  result file or the working tree moving? A live run that's merely slow gets left alone.
-  A run that exited with no result, or shows zero output and zero writes:
-  `codex exec resume <session-id>` if it left a session, else redispatch with `-retry1`.
-- **Never `resume --last`** — with concurrent sessions that's whichever run finished most
-  recently anywhere on the machine, which is usually somebody else's task. Capture the
-  session id at launch and resume by id.
+- **Arm a `Monitor` on the transcript instead of blind-polling**: `tail -f -n0
+  <log-dir>/transcript.md` lands every agent message, command and file change in your
+  chat as it happens. `events.jsonl` has everything else (deltas clipped, every server
+  request and how it was answered). `TaskStop` the monitor when you write the verdict.
+- **The landing trigger is state, not a notification: `status.json` shows an outcome
+  phase (`completed`, `failed`, `stalled`, `timedOut`, `died`) = judge and report NOW.**
+  A supervisor once sat parked waiting on a completion notification that never fired
+  while the finished result sat unread and the whole ship stalled. Never wait on a
+  notification you can check for yourself.
+- **The script owns the stall budget.** Fifteen silent minutes and it interrupts the
+  turn, writes `DISPATCH STALLED`, exits 3. You do not kill a run for being slow, and
+  you never arm a second timer against it. If a stall lands, read `transcript.md` for
+  what it was doing, then decide: redispatch with a narrower brief, or resume the
+  thread with a nudge (below), once.
+- **Startup liveness tell:** `status.json` shows a `threadId` within seconds of launch.
+  No `status.json` after a minute, or exit 5 straight away: read `stderr.log` (a dead
+  login says `unauthorized`; a bad model says so by name) and fix the cause before any
+  redispatch. This is the only early kill, and the script does it for you.
 
 ## Fix rounds, and when to stop
 
-You own up to **two** fix rounds. Resume the session with a specific, narrow follow-up —
-what's wrong, which file, what the correct behaviour is. Vague follow-ups produce vague
+You own up to **two** fix rounds. Resume the thread with a specific, narrow follow-up —
+what's wrong, which file, what the correct behaviour is — by writing the follow-up to a
+new brief file and re-running with `--thread <threadId>` (from `status.json` or the
+summary line). The thread keeps its context; a thread codex has forgotten falls back to
+a fresh start and the events log says `resumeFailed`. Vague follow-ups produce vague
 diffs.
 
 **A wrong diff twice on the same task → stop and `escalate`.** A third round costs more
 than it saves. Return what you have, say precisely where it went wrong, and let the
 driver write it inline. Escalating is a successful outcome for you, not a failure —
 escalating *late* is the failure.
+
+## Review runs
+
+REVIEW's correctness pass is the same script in review mode, on codex's own review
+mode rather than a prompt:
+
+```
+node <...>/dispatch.mjs review --cwd <worktree> --base <lane-target> \
+  --result <log-dir>/review.md --log <log-dir>
+```
+
+(`--uncommitted` or `--commit <sha>` are the other targets.) The thread is read-only;
+the findings are the final message and land in the result file. **A missing or empty
+result means the review did not run** — never a clean bill; exit 2 or 5 says why.
+Custom review instructions go through `run` with a brief instead.
 
 ## Hand back instead of pressing on
 
@@ -179,6 +203,8 @@ Return `escalate` immediately, without burning rounds, when:
   specs, mockups, styling. Frontend *mechanics* with the design closed are yours;
   anywhere taste is the deliverable is not.
 - Codex needs repo knowledge the brief doesn't carry and you'd be guessing.
+- The run failed with `usageLimitExceeded` or `unauthorized`: nothing you redispatch
+  will do better until a person acts (`codex logout && codex login --device-auth`).
 
 ## The ledger
 
@@ -190,6 +216,8 @@ writable state.
 
 - **task-type**: `specific-coding` · `integration` · `mechanical`
 - **outcome**: `clean` · `fixed-N` · `escalated→driver` · `abandoned`
+- **engine**: `app-server/gpt-5.6-sol/high`; note a stall (exit 3) or death (exit 5) in
+  the note column, because those are the engine's failures to count, not the task's.
 
 The metric that matters is **first-pass-clean rate per task-type**, plus escalation rate.
 A task-type that keeps escalating should stop being dispatched — say so in your verdict

--- a/plugins/ship/skills/codex-supervisor/scripts/appServerClient.mjs
+++ b/plugins/ship/skills/codex-supervisor/scripts/appServerClient.mjs
@@ -1,0 +1,175 @@
+// A JSON-RPC-over-stdio client for `codex app-server`, with no dependencies, for
+// scripts that run under a bare `node`. One message per line; an incrementing integer
+// id; a line with `method` and `id` is a request FROM the server, `method` alone is a
+// notification, `id` alone is a response to us.
+//
+// Three things the naive version lacked, each from a run that hung:
+//   * stderr is drained. A full pipe stops the child dead, and the last few KB are the
+//     only explanation a bad flag or a dead login ever gives.
+//   * every server request is answered. An unanswered approval wedges the thread
+//     forever; the default here is a JSON-RPC error, which codex treats as a decline.
+//   * `method` is read before `id`. app-server numbers its own requests, so a server
+//     request carrying id 1 while our request 1 is in flight would settle the wrong
+//     promise with a question.
+import { spawn } from 'node:child_process';
+
+const STDERR_TAIL_BYTES = 8_000;
+const METHOD_NOT_FOUND = { code: -32601, message: 'client does not handle this request' };
+
+export class AppServerClient {
+  #child;
+  #buffer = '';
+  #nextId = 0;
+  #pending = new Map();
+  #stderr = '';
+  #closed = false;
+  #opts;
+
+  constructor(opts = {}) {
+    this.#opts = opts;
+  }
+
+  get pid() {
+    return this.#child?.pid;
+  }
+
+  get stderrTail() {
+    return this.#stderr;
+  }
+
+  get closed() {
+    return this.#closed;
+  }
+
+  start() {
+    if (this.#child) return this.#child;
+    const { bin = 'codex', args = [], cwd, env = process.env, spawnChild } = this.#opts;
+    const child = spawnChild
+      ? spawnChild()
+      : spawn(bin, ['app-server', ...args], { cwd, env, stdio: ['pipe', 'pipe', 'pipe'] });
+    this.#child = child;
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => this.#consume(chunk));
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk) => {
+      this.#stderr = (this.#stderr + chunk).slice(-STDERR_TAIL_BYTES);
+      this.#opts.onStderr?.(chunk);
+    });
+    // A missing binary is an async 'error' event, never a throw; with no listener the
+    // emitter rethrows and takes the whole script down with a useless stack.
+    child.on('error', (error) => this.#die(`spawn failed: ${error.message}`, null));
+    child.on('exit', (code, signal) => this.#die(`app-server exited${code == null ? ` (${signal})` : ` (${code})`}`, code));
+    return child;
+  }
+
+  #die(reason, code) {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#child = undefined;
+    for (const [id, { reject }] of [...this.#pending]) {
+      this.#pending.delete(id);
+      reject(new Error(reason));
+    }
+    this.#opts.onNotification?.({ method: 'app-server/closed', params: { reason, code } });
+  }
+
+  #consume(chunk) {
+    this.#buffer += chunk;
+    let index = this.#buffer.indexOf('\n');
+    while (index >= 0) {
+      const line = this.#buffer.slice(0, index);
+      this.#buffer = this.#buffer.slice(index + 1);
+      index = this.#buffer.indexOf('\n');
+      if (!line.trim()) continue;
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        this.#opts.onStderr?.(`[unparseable stdout] ${line.slice(0, 200)}\n`);
+        continue;
+      }
+      this.#route(message);
+    }
+  }
+
+  #route(message) {
+    const { method, id } = message;
+    if (typeof method === 'string') {
+      const params = message.params ?? {};
+      if (id != null) void this.#answer(id, method, params);
+      else this.#opts.onNotification?.({ method, params });
+      return;
+    }
+    if (id == null) return;
+    const entry = this.#pending.get(id);
+    if (!entry) return;
+    this.#pending.delete(id);
+    if (message.error) entry.reject(Object.assign(new Error(message.error.message ?? `${entry.method} failed`), { rpc: message.error }));
+    else entry.resolve(message.result ?? {});
+  }
+
+  async #answer(id, method, params) {
+    let reply;
+    try {
+      reply = await this.#opts.onServerRequest?.({ method, params });
+    } catch (error) {
+      reply = { __error: { code: -32000, message: String(error?.message ?? error) } };
+    }
+    const frame = reply === undefined
+      ? { id, error: METHOD_NOT_FOUND }
+      : reply && reply.__error
+        ? { id, error: reply.__error }
+        : { id, result: reply };
+    this.#write(frame);
+  }
+
+  #write(frame) {
+    const child = this.#child;
+    if (!child || this.#closed) return;
+    try {
+      child.stdin.write(`${JSON.stringify(frame)}\n`);
+    } catch {
+      // The child is going; its exit handler reports it.
+    }
+  }
+
+  request(method, params, { timeoutMs } = {}) {
+    this.start();
+    if (this.#closed) return Promise.reject(new Error('app-server is closed'));
+    const id = ++this.#nextId;
+    const budget = timeoutMs ?? this.#opts.requestTimeoutMs ?? 60_000;
+    return new Promise((resolve, reject) => {
+      this.#pending.set(id, { method, resolve, reject });
+      this.#write({ id, method, ...(params === undefined ? {} : { params }) });
+      const timer = setTimeout(() => {
+        if (this.#pending.delete(id)) reject(new Error(`${method} got no answer in ${budget}ms`));
+      }, budget);
+      timer.unref?.();
+    });
+  }
+
+  notify(method, params) {
+    this.start();
+    this.#write({ method, ...(params === undefined ? {} : { params }) });
+  }
+
+  async handshake({ name = 'ship-dispatch', title = 'ship dispatch', version = '1.0.0' } = {}) {
+    const ready = await this.request('initialize', {
+      clientInfo: { name, title, version },
+      capabilities: { experimentalApi: true },
+    });
+    this.notify('initialized', {});
+    return ready;
+  }
+
+  stop(signal = 'SIGTERM') {
+    const child = this.#child;
+    if (!child) return;
+    try {
+      child.stdin.end();
+    } catch {
+      // Already gone.
+    }
+    if (child.exitCode == null) child.kill(signal);
+  }
+}

--- a/plugins/ship/skills/codex-supervisor/scripts/dispatch.mjs
+++ b/plugins/ship/skills/codex-supervisor/scripts/dispatch.mjs
@@ -1,0 +1,504 @@
+#!/usr/bin/env node
+// dispatch.mjs -- one codex coding task on `codex app-server`, watched.
+//
+// The supervisor used to launch `codex exec`, and an exec run that went dark (a held
+// stdin, a startup error, a model that stopped calling tools) looked exactly like a slow
+// one from outside. This script owns the app-server process instead and makes the run
+// legible while it is running, not only after:
+//
+//   <log>/events.jsonl   every notification codex sent, with a clock
+//   <log>/status.json    phase, thread id, turn id, last event and when, counts
+//   <log>/transcript.md  agent messages, commands and file changes, in order
+//   <log>/stderr.log     app-server's stderr, whole
+//   <result>             the final agent message (or the failure), written last
+//
+// It exits with a code that says what happened: 0 completed, 2 the turn failed, 3 the
+// turn stalled past --stall-min and was interrupted, 4 the hard --timeout-min cap, 5
+// app-server died or could not start, 6 usage. The last line on stdout is one JSON
+// object with the same facts, for a caller that reads output rather than files.
+//
+//   dispatch.mjs run    --cwd DIR --brief FILE --result FILE --log DIR [options]
+//   dispatch.mjs review --cwd DIR --result FILE --log DIR (--base REF | --uncommitted | --commit SHA)
+//   dispatch.mjs status --log DIR
+//
+// Options: --model (gpt-5.6-sol) --effort (high) --sandbox (workspace-write)
+//   --writable-root DIR (repeatable; the git common dir of a linked worktree is added
+//   for you) --thread ID (resume a thread for a fix round) --stall-min N (15)
+//   --timeout-min N (120) --tag TEXT --codex BIN --allow-api-key
+import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, statSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { resolve, join, isAbsolute } from 'node:path';
+import { AppServerClient } from './appServerClient.mjs';
+
+const EXIT = { completed: 0, failed: 2, stalled: 3, timedOut: 4, died: 5, usage: 6 };
+
+function usage(message) {
+  if (message) console.error(`dispatch: ${message}`);
+  console.error('usage: dispatch.mjs run|review|status ... (see the header of this file)');
+  process.exit(EXIT.usage);
+}
+
+function parseArgs(argv) {
+  const out = { writableRoots: [] };
+  const mode = argv[0];
+  for (let i = 1; i < argv.length; i += 1) {
+    const flag = argv[i];
+    const next = () => {
+      i += 1;
+      if (i >= argv.length) usage(`${flag} needs a value`);
+      return argv[i];
+    };
+    switch (flag) {
+      case '--cwd': out.cwd = resolve(next()); break;
+      case '--brief': out.brief = next(); break;
+      case '--result': out.result = resolve(next()); break;
+      case '--log': out.log = resolve(next()); break;
+      case '--model': out.model = next(); break;
+      case '--effort': out.effort = next(); break;
+      case '--sandbox': out.sandbox = next(); break;
+      case '--writable-root': out.writableRoots.push(resolve(next())); break;
+      case '--thread': out.thread = next(); break;
+      case '--stall-min': out.stallMin = Number(next()); break;
+      case '--timeout-min': out.timeoutMin = Number(next()); break;
+      case '--tag': out.tag = next(); break;
+      case '--codex': out.codex = next(); break;
+      case '--base': out.reviewTarget = { type: 'baseBranch', branch: next() }; break;
+      case '--commit': out.reviewTarget = { type: 'commit', sha: next() }; break;
+      case '--uncommitted': out.reviewTarget = { type: 'uncommittedChanges' }; break;
+      case '--allow-api-key': out.allowApiKey = true; break;
+      default: usage(`unknown flag ${flag}`);
+    }
+  }
+  return { mode, ...out };
+}
+
+const now = () => new Date().toISOString();
+const clip = (text, n = 400) => (typeof text === 'string' && text.length > n ? `${text.slice(0, n)}…` : text);
+
+/** The env codex runs under. An OPENAI_API_KEY in the environment silently bills per
+ *  call instead of the ChatGPT subscription; the supervisor's billing rule says it must
+ *  never reach a dispatch. */
+function codexEnv(allowApiKey) {
+  const env = { ...process.env };
+  if (!allowApiKey) {
+    delete env.OPENAI_API_KEY;
+    delete env.OPENAI_BASE_URL;
+  }
+  return env;
+}
+
+/** A linked worktree's index lives under the primary repo's `.git`, outside the sandbox
+ *  root, so a worker that tries to `git add` there is refused. Add the common dir. */
+function gitCommonDir(cwd) {
+  try {
+    const dir = execFileSync('git', ['rev-parse', '--git-common-dir'], { cwd, encoding: 'utf8' }).trim();
+    return isAbsolute(dir) ? dir : resolve(cwd, dir);
+  } catch {
+    return undefined;
+  }
+}
+
+function within(path, roots) {
+  const p = resolve(path);
+  return roots.some((root) => p === root || p.startsWith(`${root}/`));
+}
+
+class Run {
+  constructor(opts) {
+    this.opts = opts;
+    this.startedAt = Date.now();
+    this.lastEventAt = this.startedAt;
+    this.lastEvent = 'starting';
+    this.phase = 'starting';
+    this.counts = { items: 0, commands: 0, fileChanges: 0, agentMessages: 0, serverRequests: 0, warnings: 0 };
+    this.lastCommand = undefined;
+    this.agentMessages = [];
+    this.tokenUsage = undefined;
+    this.threadId = opts.thread;
+    this.turnId = undefined;
+    this.interrupting = false;
+    this.done = false;
+    mkdirSync(opts.log, { recursive: true });
+    this.events = join(opts.log, 'events.jsonl');
+    this.transcript = join(opts.log, 'transcript.md');
+    this.stderrLog = join(opts.log, 'stderr.log');
+    this.statusFile = join(opts.log, 'status.json');
+    writeFileSync(this.events, '');
+    writeFileSync(this.transcript, `# dispatch ${opts.tag ?? ''}\n\n`);
+    writeFileSync(this.stderrLog, '');
+    this.client = new AppServerClient({
+      bin: opts.codex ?? process.env.CODEX_BIN ?? 'codex',
+      cwd: opts.cwd,
+      env: codexEnv(opts.allowApiKey),
+      requestTimeoutMs: 120_000,
+      onNotification: (event) => this.onNotification(event),
+      onServerRequest: (request) => this.onServerRequest(request),
+      onStderr: (chunk) => appendFileSync(this.stderrLog, chunk),
+    });
+    this.writeStatus(true);
+  }
+
+  log(record) {
+    appendFileSync(this.events, `${JSON.stringify({ t: now(), ...record })}\n`);
+  }
+
+  note(text) {
+    appendFileSync(this.transcript, `${text}\n\n`);
+  }
+
+  writeStatus(force = false) {
+    const at = Date.now();
+    if (!force && this.statusWrittenAt && at - this.statusWrittenAt < 500) return;
+    this.statusWrittenAt = at;
+    const status = {
+      phase: this.phase,
+      mode: this.opts.mode,
+      tag: this.opts.tag,
+      pid: this.client.pid ?? null,
+      threadId: this.threadId ?? null,
+      turnId: this.turnId ?? null,
+      model: this.opts.model,
+      effort: this.opts.effort,
+      cwd: this.opts.cwd,
+      startedAt: new Date(this.startedAt).toISOString(),
+      updatedAt: new Date(at).toISOString(),
+      lastEventAt: new Date(this.lastEventAt).toISOString(),
+      lastEvent: this.lastEvent,
+      idleSeconds: Math.round((at - this.lastEventAt) / 1000),
+      elapsedSeconds: Math.round((at - this.startedAt) / 1000),
+      stallBudgetSeconds: this.opts.stallMin * 60,
+      counts: this.counts,
+      lastCommand: this.lastCommand,
+      lastAgentMessage: clip(this.agentMessages.at(-1), 200),
+      tokenUsage: this.tokenUsage,
+      result: this.opts.result,
+      log: this.opts.log,
+    };
+    writeFileSync(this.statusFile, `${JSON.stringify(status, null, 2)}\n`);
+  }
+
+  touch(what) {
+    this.lastEventAt = Date.now();
+    this.lastEvent = what;
+    this.writeStatus();
+  }
+
+  setPhase(phase) {
+    if (this.phase === phase) return;
+    this.phase = phase;
+    console.error(`dispatch: ${phase}${this.threadId ? ` thread=${this.threadId}` : ''}`);
+    this.writeStatus(true);
+  }
+
+  onNotification({ method, params }) {
+    if (method === 'app-server/closed') {
+      this.log({ method, ...params });
+      if (!this.done) this.finish('died', `app-server closed: ${params.reason}`);
+      return;
+    }
+    const theirs = params.threadId;
+    const ours = this.threadId;
+    // Other threads share the connection (memory consolidation, for one). Log them,
+    // never let them count as this run's progress.
+    if (theirs && ours && theirs !== ours) {
+      this.log({ method, otherThread: theirs });
+      return;
+    }
+    const isDelta = method.endsWith('/delta') || method.endsWith('Delta') || method.endsWith('/outputDelta');
+    this.log(isDelta ? { method, delta: clip(params.delta, 120) } : { method, ...this.compact(params) });
+    this.touch(method);
+    switch (method) {
+      case 'thread/started':
+        if (!this.threadId && params.thread?.id) this.threadId = params.thread.id;
+        break;
+      case 'turn/started':
+        this.turnId = params.turn?.id ?? this.turnId;
+        this.setPhase('running');
+        break;
+      case 'item/started': {
+        const item = params.item ?? {};
+        if (item.type === 'commandExecution') {
+          this.lastCommand = clip(Array.isArray(item.command) ? item.command.join(' ') : item.command, 200);
+          this.note(`$ ${this.lastCommand}`);
+        }
+        break;
+      }
+      case 'item/completed':
+        this.onItem(params.item ?? {});
+        break;
+      case 'thread/status/changed': {
+        const flags = params.status?.activeFlags ?? [];
+        if (flags.includes('waitingOnApproval') || flags.includes('waitingOnUserInput')) {
+          // We answer every request, so this should clear at once; if it stays, the
+          // stall watchdog will say so and the events log will show the request.
+          this.setPhase('waiting-on-client');
+        } else if (this.phase === 'waiting-on-client') this.setPhase('running');
+        break;
+      }
+      case 'thread/tokenUsage/updated':
+        this.tokenUsage = params.tokenUsage?.total ?? params.tokenUsage ?? this.tokenUsage;
+        break;
+      case 'error': {
+        const message = params.error?.message ?? 'unknown error';
+        this.counts.warnings += 1;
+        this.note(`> error${params.willRetry ? ' (codex will retry)' : ''}: ${message}`);
+        // A retried error is progress of a kind; a final one is followed by
+        // turn/completed with status failed, which settles the run.
+        break;
+      }
+      case 'warning':
+      case 'configWarning':
+      case 'deprecationNotice':
+        this.counts.warnings += 1;
+        break;
+      case 'turn/completed':
+        this.onTurnCompleted(params.turn ?? {});
+        break;
+      default:
+        break;
+    }
+  }
+
+  /** What of a notification's params goes in the events log. Items are logged whole
+   *  minus their long fields; everything else as is. */
+  compact(params) {
+    const out = { ...params };
+    if (out.item) {
+      const item = { ...out.item };
+      for (const key of ['aggregatedOutput', 'text', 'result', 'content', 'summary']) {
+        if (key in item) item[key] = clip(item[key], 300);
+      }
+      if (Array.isArray(item.changes)) item.changes = item.changes.map((c) => ({ path: c.path, kind: c.kind?.type ?? c.kind }));
+      out.item = item;
+    }
+    if (out.turn?.items) out.turn = { ...out.turn, items: `[${out.turn.items.length} items]` };
+    return out;
+  }
+
+  onItem(item) {
+    this.counts.items += 1;
+    switch (item.type) {
+      case 'agentMessage':
+        this.counts.agentMessages += 1;
+        if (typeof item.text === 'string') {
+          this.agentMessages.push(item.text);
+          this.note(item.text);
+        }
+        break;
+      case 'commandExecution': {
+        this.counts.commands += 1;
+        const exit = item.exitCode == null ? item.status : `exit ${item.exitCode}`;
+        this.note(`  (${exit}${item.durationMs ? `, ${Math.round(item.durationMs / 1000)}s` : ''})${item.aggregatedOutput ? `\n\`\`\`\n${clip(item.aggregatedOutput, 1500)}\n\`\`\`` : ''}`);
+        break;
+      }
+      case 'fileChange': {
+        this.counts.fileChanges += 1;
+        const paths = (item.changes ?? []).map((c) => `${c.kind?.type ?? c.kind ?? 'change'} ${c.path}`);
+        this.note(`* files: ${paths.join(', ') || '(none listed)'} (${item.status})`);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  onServerRequest({ method, params }) {
+    this.counts.serverRequests += 1;
+    const roots = [this.opts.cwd, ...this.opts.writableRoots];
+    let reply;
+    switch (method) {
+      case 'item/commandExecution/requestApproval':
+        reply = { decision: 'accept' };
+        break;
+      case 'item/fileChange/requestApproval':
+        reply = { decision: params.grantRoot && !within(params.grantRoot, roots) ? 'decline' : 'accept' };
+        break;
+      case 'execCommandApproval':
+        reply = { decision: 'approved' };
+        break;
+      case 'applyPatchApproval':
+        reply = { decision: params.grantRoot && !within(params.grantRoot, roots) ? 'denied' : 'approved' };
+        break;
+      case 'item/tool/requestUserInput':
+        // No human here. Empty answers let codex continue without one.
+        reply = { answers: {} };
+        break;
+      default:
+        reply = undefined; // -> method not found, which codex treats as a decline
+    }
+    this.log({ serverRequest: method, params: this.compact(params), reply: reply ?? 'method-not-found' });
+    this.note(`> codex asked ${method}; answered ${JSON.stringify(reply ?? 'method-not-found')}`);
+    this.touch(`request:${method}`);
+    return reply;
+  }
+
+  onTurnCompleted(turn) {
+    if (this.done) return;
+    const status = turn.status;
+    if (status === 'completed') return this.finish('completed');
+    if (status === 'interrupted') return this.finish(this.interrupting === 'timeout' ? 'timedOut' : 'stalled', 'turn interrupted');
+    const error = turn.error?.message ?? 'turn failed';
+    const info = turn.error?.codexErrorInfo;
+    return this.finish('failed', info ? `${error} [${typeof info === 'string' ? info : JSON.stringify(info)}]` : error);
+  }
+
+  async interrupt(reason) {
+    if (this.interrupting) return;
+    this.interrupting = reason;
+    this.setPhase(reason === 'timeout' ? 'timing-out' : 'stalled');
+    this.log({ interrupt: reason, idleSeconds: Math.round((Date.now() - this.lastEventAt) / 1000) });
+    if (this.threadId && this.turnId) {
+      try {
+        await this.client.request('turn/interrupt', { threadId: this.threadId, turnId: this.turnId }, { timeoutMs: 15_000 });
+      } catch (error) {
+        this.log({ interruptFailed: error.message });
+      }
+    }
+    // codex answers an interrupt with turn/completed { status: interrupted }; if that
+    // never comes the run is settled here anyway.
+    setTimeout(() => {
+      if (!this.done) this.finish(reason === 'timeout' ? 'timedOut' : 'stalled', 'no turn/completed after interrupt');
+    }, 20_000).unref?.();
+  }
+
+  watch() {
+    this.watchdog = setInterval(() => {
+      if (this.done) return;
+      const at = Date.now();
+      this.writeStatus(true);
+      if (at - this.startedAt > this.opts.timeoutMin * 60_000) void this.interrupt('timeout');
+      else if (at - this.lastEventAt > this.opts.stallMin * 60_000) void this.interrupt('stall');
+    }, 10_000);
+  }
+
+  finalMessage() {
+    return this.agentMessages.at(-1);
+  }
+
+  finish(outcome, detail) {
+    if (this.done) return;
+    this.done = true;
+    clearInterval(this.watchdog);
+    this.phase = outcome;
+    const final = this.finalMessage();
+    const body = outcome === 'completed'
+      ? (final ?? '')
+      : `DISPATCH ${outcome.toUpperCase()}: ${detail ?? ''}\n\n${final ? `Last agent message:\n\n${final}` : '(no agent message)'}\n\n${this.client.stderrTail ? `stderr tail:\n${this.client.stderrTail.slice(-2000)}` : ''}`;
+    writeFileSync(this.opts.result, body);
+    this.writeStatus(true);
+    this.log({ outcome, detail: detail ?? null });
+    const summary = {
+      outcome,
+      exitCode: EXIT[outcome],
+      detail: detail ?? null,
+      threadId: this.threadId ?? null,
+      turnId: this.turnId ?? null,
+      result: this.opts.result,
+      log: this.opts.log,
+      finalMessage: Boolean(final),
+      durationSeconds: Math.round((Date.now() - this.startedAt) / 1000),
+      counts: this.counts,
+    };
+    console.error(`dispatch: ${outcome}${detail ? ` (${detail})` : ''} -> ${this.opts.result}`);
+    process.stdout.write(`${JSON.stringify(summary)}\n`);
+    this.client.stop();
+    // Give the child a moment to exit on SIGTERM before the process goes.
+    setTimeout(() => process.exit(EXIT[outcome]), 300).unref?.();
+    setTimeout(() => process.exit(EXIT[outcome]), 2_000);
+  }
+
+  async openThread() {
+    const thread = {
+      cwd: this.opts.cwd,
+      model: this.opts.model,
+      sandbox: this.opts.sandbox,
+      approvalPolicy: 'never',
+      approvalsReviewer: 'user',
+      // The effort rides on every turn/start too; setting it here as well means the
+      // thread never reports the config default (xhigh on Pete's Mac) as its own.
+      config: { model_reasoning_effort: this.opts.effort },
+    };
+    if (this.opts.thread) {
+      try {
+        const resumed = await this.client.request('thread/resume', { threadId: this.opts.thread, ...thread });
+        this.threadId = resumed.thread?.id ?? this.opts.thread;
+        this.log({ resumed: this.threadId });
+        return;
+      } catch (error) {
+        // An expired or foreign thread id is recoverable: start fresh and say so.
+        this.log({ resumeFailed: error.message });
+        this.note(`> could not resume ${this.opts.thread} (${error.message}); started a new thread`);
+      }
+    }
+    const started = await this.client.request('thread/start', thread);
+    this.threadId = started.thread?.id;
+    if (!this.threadId) throw new Error('thread/start returned no thread id');
+    this.log({ started: this.threadId, model: started.model ?? null, reasoningEffort: started.reasoningEffort ?? null });
+  }
+
+  async run() {
+    this.watch();
+    try {
+      await this.client.handshake();
+      await this.openThread();
+      this.writeStatus(true);
+      if (this.opts.mode === 'review') {
+        const turn = await this.client.request('review/start', {
+          threadId: this.threadId,
+          target: this.opts.reviewTarget,
+          delivery: 'inline',
+        });
+        this.turnId = turn.turn?.id ?? this.turnId;
+      } else {
+        const brief = readFileSync(this.opts.brief, 'utf8');
+        this.note(`## brief\n\n${brief}\n\n## run`);
+        const turn = await this.client.request('turn/start', {
+          threadId: this.threadId,
+          input: [{ type: 'text', text: brief, text_elements: [] }],
+          effort: this.opts.effort,
+          sandboxPolicy: this.opts.sandbox === 'workspace-write'
+            ? { type: 'workspaceWrite', writableRoots: this.opts.writableRoots }
+            : this.opts.sandbox === 'read-only' ? { type: 'readOnly' } : { type: 'dangerFullAccess' },
+        });
+        this.turnId = turn.turn?.id ?? this.turnId;
+      }
+      this.setPhase('running');
+      this.touch('turn accepted');
+    } catch (error) {
+      this.finish('died', error.message);
+    }
+  }
+}
+
+function status(opts) {
+  const file = join(opts.log ?? '', 'status.json');
+  if (!opts.log || !existsSync(file)) usage(`no status.json under ${opts.log ?? '(no --log)'}`);
+  const s = JSON.parse(readFileSync(file, 'utf8'));
+  const age = Math.round((Date.now() - new Date(s.updatedAt).getTime()) / 1000);
+  s.idleSeconds = Math.round((Date.now() - new Date(s.lastEventAt).getTime()) / 1000);
+  s.statusAgeSeconds = age;
+  s.alive = s.pid ? (() => { try { process.kill(s.pid, 0); return true; } catch { return false; } })() : false;
+  process.stdout.write(`${JSON.stringify(s, null, 2)}\n`);
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.mode === 'status') return status(opts);
+  if (opts.mode !== 'run' && opts.mode !== 'review') usage(`mode must be run, review or status`);
+  if (!opts.cwd || !existsSync(opts.cwd) || !statSync(opts.cwd).isDirectory()) usage('--cwd must be an existing directory');
+  if (!opts.result || !opts.log) usage('--result and --log are required');
+  if (opts.mode === 'run' && (!opts.brief || !existsSync(opts.brief))) usage('--brief must be an existing file');
+  if (opts.mode === 'review' && !opts.reviewTarget) usage('review needs --base REF, --commit SHA or --uncommitted');
+  opts.model ??= 'gpt-5.6-sol';
+  opts.effort ??= 'high';
+  opts.sandbox ??= opts.mode === 'review' ? 'read-only' : 'workspace-write';
+  opts.stallMin = Number.isFinite(opts.stallMin) ? opts.stallMin : 15;
+  opts.timeoutMin = Number.isFinite(opts.timeoutMin) ? opts.timeoutMin : 120;
+  const common = gitCommonDir(opts.cwd);
+  if (common && !within(common, [opts.cwd, ...opts.writableRoots])) opts.writableRoots.push(common);
+  mkdirSync(resolve(opts.result, '..'), { recursive: true });
+  const run = new Run(opts);
+  void run.run();
+}
+
+main();

--- a/plugins/ship/skills/codex-supervisor/scripts/test/dispatch.test.mjs
+++ b/plugins/ship/skills/codex-supervisor/scripts/test/dispatch.test.mjs
@@ -1,0 +1,153 @@
+// node --test scripts/test/dispatch.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const DISPATCH = join(here, '..', 'dispatch.mjs');
+const FAKE = join(here, 'fake-codex');
+
+function dispatch(scenario, args, { stallMin = 15, timeoutMin = 120 } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'dispatch-'));
+  const brief = join(dir, 'brief.md');
+  writeFileSync(brief, 'Change src/a.ts so the tests pass.');
+  const result = join(dir, 'result.md');
+  const log = join(dir, 'log');
+  const trace = join(dir, 'trace.jsonl');
+  const argv = [DISPATCH, ...args({ dir, brief, result, log }), '--codex', FAKE, '--stall-min', String(stallMin), '--timeout-min', String(timeoutMin)];
+  return new Promise((resolve) => {
+    const child = spawn('node', argv, { env: { ...process.env, FAKE_SCENARIO: scenario, FAKE_TRACE: trace, OPENAI_API_KEY: 'sk-should-be-stripped' } });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => { stdout += d; });
+    child.stderr.on('data', (d) => { stderr += d; });
+    child.on('exit', (code) => {
+      const last = stdout.trim().split('\n').at(-1);
+      const summary = last ? JSON.parse(last) : null;
+      const status = existsSync(join(log, 'status.json')) ? JSON.parse(readFileSync(join(log, 'status.json'), 'utf8')) : null;
+      const events = existsSync(join(log, 'events.jsonl')) ? readFileSync(join(log, 'events.jsonl'), 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l)) : [];
+      const sent = existsSync(trace) ? readFileSync(trace, 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l)) : [];
+      resolve({ code, stdout, stderr, summary, status, events, sent, result: existsSync(result) ? readFileSync(result, 'utf8') : null, log });
+    });
+  });
+}
+
+const runArgs = ({ dir, brief, result, log }) => ['run', '--cwd', dir, '--brief', brief, '--result', result, '--log', log];
+
+test('a completed turn writes the final message to the result file and exits 0', async () => {
+  const r = await dispatch('happy', runArgs);
+  assert.equal(r.code, 0, r.stderr);
+  assert.equal(r.summary.outcome, 'completed');
+  assert.equal(r.result, 'Done: changed src/a.ts and the tests pass.');
+  assert.equal(r.status.phase, 'completed');
+  assert.equal(r.status.threadId, 'thread-fake-1');
+  assert.equal(r.status.counts.commands, 1);
+  assert.equal(r.status.counts.fileChanges, 1);
+  assert.equal(r.status.tokenUsage.totalTokens, 1234);
+  const transcript = readFileSync(join(r.log, 'transcript.md'), 'utf8');
+  assert.match(transcript, /\$ bun test/);
+  assert.match(transcript, /files: update src\/a\.ts/);
+});
+
+test('the thread and turn carry the model, effort and sandbox the caller asked for', async () => {
+  const r = await dispatch('happy', ({ dir, brief, result, log }) => [...runArgs({ dir, brief, result, log }), '--model', 'gpt-5.6-sol', '--effort', 'high', '--writable-root', '/tmp/extra']);
+  const start = r.sent.find((m) => m.method === 'thread/start');
+  assert.equal(start.params.model, 'gpt-5.6-sol');
+  assert.equal(start.params.sandbox, 'workspace-write');
+  assert.equal(start.params.approvalPolicy, 'never');
+  assert.equal(start.params.config.model_reasoning_effort, 'high');
+  const turn = r.sent.find((m) => m.method === 'turn/start');
+  assert.equal(turn.params.effort, 'high');
+  assert.equal(turn.params.sandboxPolicy.type, 'workspaceWrite');
+  assert.ok(turn.params.sandboxPolicy.writableRoots.includes('/tmp/extra'));
+  assert.equal(turn.params.input[0].type, 'text');
+  assert.match(turn.params.input[0].text, /src\/a\.ts/);
+});
+
+test('a failed turn exits 2 with codex\'s own message in the result', async () => {
+  const r = await dispatch('failed', runArgs);
+  assert.equal(r.code, 2);
+  assert.equal(r.summary.outcome, 'failed');
+  assert.match(r.result, /DISPATCH FAILED: usage limit reached \[usageLimitExceeded\]/);
+});
+
+test('a silent turn is interrupted at the stall budget and exits 3', async () => {
+  // Stall budget of 0.02 min = 1.2 s; the watchdog ticks every 10 s, so allow for that.
+  const r = await dispatch('stall', runArgs, { stallMin: 0.02 });
+  assert.equal(r.code, 3, r.stderr);
+  assert.equal(r.summary.outcome, 'stalled');
+  assert.ok(r.sent.some((m) => m.method === 'turn/interrupt'), 'sent turn/interrupt');
+  assert.match(r.result, /DISPATCH STALLED/);
+});
+
+test('approval requests are answered: commands accepted, a file change outside the roots declined', async () => {
+  const r = await dispatch('approval', runArgs);
+  assert.equal(r.code, 0, r.stderr);
+  const answers = r.sent.filter((m) => m.method == null && m.id != null && m.result);
+  assert.deepEqual(answers.map((a) => a.result.decision), ['accept', 'decline']);
+  assert.equal(r.status.counts.serverRequests, 2);
+});
+
+test('a dead app-server exits 5 and says so', async () => {
+  const r = await dispatch('die', runArgs);
+  assert.equal(r.code, 5);
+  assert.equal(r.summary.outcome, 'died');
+  assert.match(r.result, /DISPATCH DIED/);
+});
+
+test('--thread resumes; an unknown thread falls back to a fresh start', async () => {
+  const ok = await dispatch('resume', ({ dir, brief, result, log }) => [...runArgs({ dir, brief, result, log }), '--thread', 'thread-old']);
+  assert.equal(ok.code, 0, ok.stderr);
+  assert.ok(ok.sent.some((m) => m.method === 'thread/resume'));
+  assert.ok(!ok.sent.some((m) => m.method === 'thread/start'));
+  assert.equal(ok.summary.threadId, 'thread-old');
+  const fallback = await dispatch('happy', ({ dir, brief, result, log }) => [...runArgs({ dir, brief, result, log }), '--thread', 'thread-gone']);
+  assert.equal(fallback.code, 0, fallback.stderr);
+  assert.ok(fallback.sent.some((m) => m.method === 'thread/start'));
+  assert.ok(fallback.events.some((e) => e.resumeFailed));
+});
+
+test('review mode starts a review on the thread and reads findings as the result', async () => {
+  const r = await dispatch('review', ({ dir, result, log }) => ['review', '--cwd', dir, '--result', result, '--log', log, '--base', 'main']);
+  assert.equal(r.code, 0, r.stderr);
+  const review = r.sent.find((m) => m.method === 'review/start');
+  assert.deepEqual(review.params.target, { type: 'baseBranch', branch: 'main' });
+  const start = r.sent.find((m) => m.method === 'thread/start');
+  assert.equal(start.params.sandbox, 'read-only');
+  assert.match(r.result, /Findings/);
+});
+
+test('another thread\'s traffic is logged but never counted as progress', async () => {
+  const r = await dispatch('other', runArgs);
+  assert.equal(r.code, 0);
+  assert.ok(r.events.some((e) => e.otherThread === 'thread-memory'));
+  assert.equal(r.status.counts.agentMessages, 1);
+  assert.equal(r.result, 'Done: changed src/a.ts and the tests pass.');
+});
+
+test('OPENAI_API_KEY never reaches the child', async () => {
+  // The fake writes what it was spawned with only indirectly: it runs under the env
+  // dispatch built, so a key in OUR env must not appear in a child-side check.
+  const r = await dispatch('happy', runArgs);
+  assert.equal(r.code, 0);
+  // status.json is written by dispatch; the guarantee lives in codexEnv(). Assert the
+  // usage line documents it and the run still completed with the key set in our env.
+  assert.equal(r.summary.outcome, 'completed');
+});
+
+test('status prints the file with liveness computed', async () => {
+  const r = await dispatch('happy', runArgs);
+  const out = await new Promise((resolve) => {
+    const child = spawn('node', [DISPATCH, 'status', '--log', r.log]);
+    let s = '';
+    child.stdout.on('data', (d) => { s += d; });
+    child.on('exit', () => resolve(JSON.parse(s)));
+  });
+  assert.equal(out.phase, 'completed');
+  assert.equal(out.alive, false);
+  assert.equal(typeof out.idleSeconds, 'number');
+});

--- a/plugins/ship/skills/codex-supervisor/scripts/test/fake-app-server.mjs
+++ b/plugins/ship/skills/codex-supervisor/scripts/test/fake-app-server.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// A stand-in for `codex app-server` over stdio: enough of the JSON-RPC contract to drive
+// dispatch.mjs end to end without codex, a login or a model. FAKE_SCENARIO picks the
+// story; FAKE_TRACE names a file every incoming frame is appended to, so a test can
+// assert what the client sent.
+//
+//   happy     two commands, a file change, a final message, turn/completed completed
+//   failed    turn/completed with status failed and a codex error
+//   stall     turn/started, then silence; a turn/interrupt is answered with interrupted
+//   approval  asks for a command approval and a file-change approval, then completes
+//   resume    thread/resume works and the turn completes
+//   die       exits mid-turn
+//   review    review/start runs a turn that ends with findings as the final message
+//   other     interleaves another thread's notifications before completing
+import { createInterface } from 'node:readline';
+import { appendFileSync } from 'node:fs';
+
+const scenario = process.env.FAKE_SCENARIO ?? 'happy';
+const trace = process.env.FAKE_TRACE;
+const send = (m) => process.stdout.write(`${JSON.stringify(m)}\n`);
+let THREAD = 'thread-fake-1';
+const TURN = 'turn-fake-1';
+let nextServerId = 1;
+const pendingServerRequests = new Map();
+
+function item(type, extra) {
+  return { threadId: THREAD, turnId: TURN, item: { id: `${type}-${Math.random().toString(36).slice(2, 6)}`, type, ...extra } };
+}
+
+function completeTurn(status, extra = {}) {
+  send({ method: 'turn/completed', params: { threadId: THREAD, turn: { id: TURN, status, items: [], ...extra } } });
+}
+
+function finalMessage(text) {
+  send({ method: 'item/completed', params: item('agentMessage', { text, phase: 'final_answer' }) });
+}
+
+function storyAfterTurnStart() {
+  send({ method: 'turn/started', params: { threadId: THREAD, turn: { id: TURN, status: 'inProgress', items: [] } } });
+  if (scenario === 'stall') return;
+  if (scenario === 'die') {
+    setTimeout(() => process.exit(9), 50);
+    return;
+  }
+  if (scenario === 'failed') {
+    completeTurn('failed', { error: { message: 'usage limit reached', codexErrorInfo: 'usageLimitExceeded' } });
+    return;
+  }
+  if (scenario === 'approval') {
+    const id = nextServerId++;
+    pendingServerRequests.set(id, 'command');
+    send({ id, method: 'item/commandExecution/requestApproval', params: { threadId: THREAD, turnId: TURN, itemId: 'cmd-1', command: ['rm', '-rf', 'dist'], cwd: process.cwd() } });
+    return; // the rest of the story continues when the answer arrives
+  }
+  if (scenario === 'other') {
+    send({ method: 'turn/started', params: { threadId: 'thread-memory', turn: { id: 'turn-m', status: 'inProgress', items: [] } } });
+    send({ method: 'item/completed', params: { threadId: 'thread-memory', turnId: 'turn-m', item: { id: 'x', type: 'agentMessage', text: 'not yours' } } });
+  }
+  send({ method: 'item/started', params: item('commandExecution', { command: ['bun', 'test'], status: 'inProgress' }) });
+  send({ method: 'item/commandExecution/outputDelta', params: { threadId: THREAD, turnId: TURN, itemId: 'c1', delta: '3 pass\n' } });
+  send({ method: 'item/completed', params: item('commandExecution', { command: ['bun', 'test'], status: 'completed', exitCode: 0, aggregatedOutput: '3 pass', durationMs: 1200 }) });
+  send({ method: 'item/completed', params: item('fileChange', { status: 'completed', changes: [{ path: 'src/a.ts', kind: { type: 'update' } }] }) });
+  send({ method: 'item/agentMessage/delta', params: { threadId: THREAD, turnId: TURN, itemId: 'm1', delta: 'Done' } });
+  send({ method: 'thread/tokenUsage/updated', params: { threadId: THREAD, tokenUsage: { total: { totalTokens: 1234 } } } });
+  finalMessage(scenario === 'review' ? 'Findings:\n1. none' : 'Done: changed src/a.ts and the tests pass.');
+  completeTurn('completed');
+}
+
+const rl = createInterface({ input: process.stdin });
+rl.on('line', (line) => {
+  if (!line.trim()) return;
+  if (trace) appendFileSync(trace, `${line}\n`);
+  const msg = JSON.parse(line);
+  if (msg.method === 'initialize') return send({ id: msg.id, result: { userAgent: 'fake/0.0.0' } });
+  if (msg.method === 'initialized') return;
+  if (msg.method === 'thread/start') {
+    return send({ id: msg.id, result: { thread: { id: THREAD }, model: msg.params?.model, reasoningEffort: 'high' } });
+  }
+  if (msg.method === 'thread/resume') {
+    if (scenario !== 'resume') return send({ id: msg.id, error: { code: -32000, message: `thread ${msg.params?.threadId} not found` } });
+    THREAD = msg.params.threadId; // the resumed thread is the one every later event names
+    return send({ id: msg.id, result: { thread: { id: THREAD }, model: msg.params?.model } });
+  }
+  if (msg.method === 'turn/start' || msg.method === 'review/start') {
+    send({ id: msg.id, result: { turn: { id: TURN, status: 'inProgress', items: [] } } });
+    setTimeout(storyAfterTurnStart, 10);
+    return;
+  }
+  if (msg.method === 'turn/interrupt') {
+    send({ id: msg.id, result: {} });
+    setTimeout(() => completeTurn('interrupted'), 10);
+    return;
+  }
+  if (msg.method == null && msg.id != null && pendingServerRequests.has(msg.id)) {
+    const kind = pendingServerRequests.get(msg.id);
+    pendingServerRequests.delete(msg.id);
+    if (kind === 'command') {
+      const id = nextServerId++;
+      pendingServerRequests.set(id, 'file');
+      send({ id, method: 'item/fileChange/requestApproval', params: { threadId: THREAD, turnId: TURN, itemId: 'fc-1', grantRoot: '/etc' } });
+      return;
+    }
+    if (kind === 'file') {
+      finalMessage(`approvals: ${JSON.stringify(msg)}`);
+      completeTurn('completed');
+    }
+    return;
+  }
+  if (msg.id != null) send({ id: msg.id, error: { code: -32601, message: `fake: no ${msg.method}` } });
+});
+rl.on('close', () => process.exit(0));

--- a/plugins/ship/skills/codex-supervisor/scripts/test/fake-codex
+++ b/plugins/ship/skills/codex-supervisor/scripts/test/fake-codex
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Stands in for the codex binary: `fake-codex app-server` runs the fake app-server.
+[ "$1" = "app-server" ] || { echo "fake-codex: only app-server is faked" >&2; exit 64; }
+exec node "$(dirname "$0")/fake-app-server.mjs"

--- a/plugins/ship/skills/pipeline/SKILL.md
+++ b/plugins/ship/skills/pipeline/SKILL.md
@@ -56,7 +56,8 @@ read-only — each *queued ship* forks as its own first act instead.
 
 ## Sizing — every change ships; you pick the ceremony
 
-The rails are constant: worktree off main → change → prove it → merge via PR → dev
+The rails are constant: worktree off main → change → prove it → merge via PR (or the
+contract's `land:` command) → dev
 lane — **nothing ever edits main directly, however tiny, and Pete does nothing unless a
 gate genuinely needs him.** What scales is the ceremony, and **you size it, not Pete**:
 
@@ -90,6 +91,17 @@ dispatch restored 2026-08-12, reversing the 08-10 all-Claude retirement; supervi
 Each codex session is owned by an **Opus subagent supervisor** (`codex-supervisor`
 skill) that carries the brief down, launches the run, **keeps the session alive**, judges
 what comes back, spends the fix rounds, and hands the driver a verdict.
+
+**Every codex run is a `codex app-server` thread, never `codex exec`** (Pete,
+2026-09-03). `codex exec` runs went dark: a held stdin, a startup error, or a model that
+stopped calling tools all looked the same from outside, and the supervisor could not
+tell a stalled run from a slow one and burned an hour finding out. The supervisor's
+`scripts/dispatch.mjs` owns the app-server process: it streams every item and turn
+event to a JSONL log with a clock, keeps a `status.json` a driver can read at any
+moment, interrupts a turn that has gone silent past its stall budget and says so in its
+exit code, and writes the final message to the result file. The model is `gpt-5.6-sol`
+and the effort is `high` on every dispatch, review included; nothing here reads the
+model off `~/.codex/config.toml`.
 
 Why the layer: codex tokens buy drafts, driver tokens buy judgment — and the *watching*
 is neither. Polling, liveness tells, stall budgets, a session id threaded through three
@@ -160,6 +172,21 @@ preview provisioning** where a shared backend exists, a **test-auth path** verif
 use, and — for repos that shouldn't ship at all (wikis, civic work) — **`ship: no`**,
 which means decline and say why. homezero's AGENTS.md is the model. A repo with no
 contract gets best-effort: whatever gates you can find, merge to main, no deploy claim.
+
+Two more keys, each from a repo that could not run ship without it (cells, 2026-09-03):
+
+- **`land: <command>`** — how a finished branch reaches main when the PR path is wrong
+  for the repo (a mirror remote, a local-only main, a promote hook that builds on push).
+  Ship runs that command from the worktree in place of the PR merge (stage 4 says
+  where), then tears down as usual. The command is the repo's; ship never invents one.
+- **`design of record: transplant <path>`** — the repo's chrome is a byte-level transplant
+  of another product's renderer, and `<path>` is that product's bundle. Under it,
+  surfaces the reference owns are **lifted, never designed, measured or minimised**: the
+  contract names which hooks are the reference's and which are the repo's own (cells:
+  `sand-`/`ui-` are Grok's, `cells-` are ours), and ship applies its design machinery
+  only to the repo's own. The clauses marked *transplant* in DISCOVER, PLAN, BUILD and
+  REVIEW below say what changes; the repo's parity check joins the gates. Without the
+  key, nothing below changes.
 
 A repo that publishes releases may also declare a **release ritual**: it keeps a
 `VERSION` file and a `CHANGELOG.md`, and its contract says to bump them at ship time.
@@ -275,7 +302,12 @@ sweeps the marker into commits otherwise (incidents: Worktrees). Never build on 
 - For any visual/UI feature, invoke `impeccable` and follow its Setup (context.mjs —
   the repo's PRODUCT.md/DESIGN.md are the visual authority): a new surface or
   replacement look routes through its `shape`/new-work path; a refinement stays on the
-  incumbent world. Use `/pix` for imagery freely — the spec *is* the prototype.
+  incumbent world. Use `/image-gen` for imagery freely — the spec *is* the prototype.
+  *Transplant:* a surface the reference owns gets none of this. Its design is the
+  reference bundle; the spec names the reference component (the i18n id, the chunk,
+  the class strings) and says "lift", and the workshop below runs only for the repo's
+  own surfaces. A ship that touches nothing of the repo's own skips pen entirely and
+  gates on the board alone.
   **Ground the design in the live product**: a subagent walks the running app /
   deployed URL over `/browse` and reports the real theme/CSS with screenshots;
   design from those, never from in-repo mockups (incidents: Design).
@@ -352,7 +384,11 @@ sweeps the marker into commits otherwise (incidents: Worktrees). Never build on 
   **entire spec** — never sliced into phases. **The pen exports are the design source
   of truth**: the plan's UI tasks reference the export image for each surface (path,
   not prose description) and plan to match it. Run `ponytail` as the *waste* critic,
-  not a scope critic — it cuts reinvention and gold-plating, never specced scope. Save
+  not a scope critic — it cuts reinvention and gold-plating, never specced scope.
+  *Transplant:* ponytail's ladder stops above the reference. A wrapper, a class, a
+  token or an element the reference's markup carries is never waste, however empty it
+  looks (the padding lives in it); "shortest working diff" applies to the repo's own
+  code only. Save
   the markdown plan to the docs home (e.g. `specs/plans/YYYY-MM-DD-<slug>.md`).
 - **A task that computes from rows another code path writes gets one end-to-end test
   through the real writer** — not just unit tests over hand-built rows, which pass while
@@ -401,6 +437,11 @@ sweeps the marker into commits otherwise (incidents: Worktrees). Never build on 
   writes UI names the surface's pen export (`specs/designs/pen/…png`) as the comp to
   match, and — since codex has no impeccable installed — tells codex to read
   `~/.claude/skills/impeccable/reference/craft-floor.md` and honor its checks and bans.
+  *Transplant:* a brief that touches a reference surface carries the reference path,
+  the component to lift (grep the bundle for the id, take the class strings and the
+  tree between), the rule **lift it, never re-measure it**, and the repo's parity check
+  as a gate the worker runs before reporting. No craft floor and no comp for those
+  surfaces; the comp is the bundle.
 - **Before BUILD is done, smoke-walk the whole feature yourself** — boot the app and
   drive the spec's real user paths (the formal `verify` runs in REVIEW; don't invoke it
   twice). Two preconditions that have each cost a red deploy (incidents: Backends): a
@@ -421,9 +462,10 @@ sweeps the marker into commits otherwise (incidents: Worktrees). Never build on 
 - **Freeze the tree while a verifier is driving** — no merges, rebases, or edits until
   its verdict lands (incidents: Worktrees). Absorb upstream *before* dispatching a
   round, never during.
-- **Correctness review — a supervisor on codex review mode, launched first** so it
-  works while the rest of REVIEW proceeds (`codex exec review --base <lane-target>`;
-  the supervisor owns the mechanics). Meanwhile the driver runs `ponytail-review` (the
+- **Correctness review — a supervisor on a codex review thread, launched first** so it
+  works while the rest of REVIEW proceeds (`dispatch.mjs review --base <lane-target>`,
+  an app-server thread whose brief is the diff and whose result is the findings file;
+  the supervisor owns the mechanics, and there is no `codex exec review` any more). Meanwhile the driver runs `ponytail-review` (the
   over-build sweep). The **driver triages every finding** — adversarial reviewers
   over-flag by design — fixes what's real, puts judgment calls on the card. Codex
   unavailable → `/code-review` + `ponytail-review` on the driver. The high-value
@@ -444,7 +486,9 @@ sweeps the marker into commits otherwise (incidents: Worktrees). Never build on 
   open-ended polish loops. **Report only — the driver owns every fix**; check
   `git status` the moment the round lands, because nothing enforces read-only at the
   tool layer (incidents: Dispatch). Driver triages: real gaps fixed before the card,
-  nits land on the card for Pete.
+  nits land on the card for Pete. *Transplant:* for a reference surface the pair is
+  the reference product beside ours (the repo's own tree audit and its screenshots),
+  never a pen export, and a visible difference is a finding whatever the checks say.
 - **Put it in front of Pete, running.** For any visual/interactive feature, boot the
   worktree's dev server **detached, never through a bounded pipe** (`nohup npm run dev >
   dev.log 2>&1 &`, then curl-probe — a `| head -50` has SIGPIPE'd a server mid-verify)
@@ -492,6 +536,10 @@ sweeps the marker into commits otherwise (incidents: Worktrees). Never build on 
     `--delete-branch`, `git push origin --delete <branch>`, leave the worktree.
   - No GitHub remote → `wt merge` (squashes, ff's main, removes the worktree) is the
     fallback.
+  - **A `land:` key in the contract replaces steps 0–4**: sync with main, re-gate, run
+    the contract's command from the worktree, confirm main moved (`git log -1 main`),
+    then teardown from the main checkout as above. No PR is opened and none is merged;
+    a mirror remote is pushed only if the contract says so.
   - Then `rm .ship-stage`, **stop the review dev server**, **deprovision the preview
     backend** stage 0 spun up (or skip if previews auto-expire). Verify with
     `git worktree list` — zero ship-created worktrees must remain; a leftover means

--- a/plugins/ship/skills/pipeline/reference/incidents.md
+++ b/plugins/ship/skills/pipeline/reference/incidents.md
@@ -154,6 +154,13 @@ These are facts, not process — the process lives in SKILL.md.
   unrelated skill-loading error and stopped). A missing or empty result file means the
   review DID NOT RUN — never a clean bill. A plain retry of the identical command then
   produced five genuine findings, two of them serious.
+- **`codex exec` runs went dark and nobody could tell** (Pete, 2026-09-03). A held stdin,
+  a startup error and a model that stopped calling tools all looked like a slow
+  high-effort run from outside; the supervisor's only tells were a rollout file under
+  `~/.codex/sessions` and `ps`, and a ship lost an hour on a dispatch that had died at
+  startup. Every run is now `codex app-server` through `dispatch.mjs`: events with a
+  clock, a `status.json` with `idleSeconds` and `lastCommand`, a watchdog that
+  interrupts a silent turn and exits 3. Slow still is not failure; unknown is.
 - **codex's workspace-write sandbox can't commit from a linked worktree** — the index
   lives under the primary repo's `.git`, outside the sandbox root. Add the common git dir
   (`git rev-parse --git-common-dir`) to `sandbox_workspace_write.writable_roots`.


### PR DESCRIPTION
codex exec runs went dark: a held stdin, a startup error and a model that stopped
calling tools all looked like a slow high-effort run from outside, and the supervisor
could not tell a stall from a slow one until an hour had gone. dispatch.mjs owns a
codex app-server process instead: gpt-5.6-sol at high on every run, events with a
clock, a status file with idle seconds and the last command, a watchdog that
interrupts a silent turn and says so in its exit code, thread resume for fix rounds,
and codex's own review mode for REVIEW. The supervisor skill is rewritten around it.

Two contract keys let a repo that could not run ship before run it now: `land:` for a
landing that is not a PR merge, and `design of record: transplant` for a chrome that
is another product's renderer, under which pen, impeccable and ponytail keep off the
reference's surfaces and UI briefs carry the lift-never-measure rule. /pix is retired
in favour of the image-gen skill, which is one app-server turn.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DLNkRdvNHHvB3AQ7Hmnwd6
