### PR TITLE
DISCOVER opens with a storyboard, and the plan waits for go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # ship
 
-A Claude Code plugin: **`/ship`** takes a feature from **idea to merged in one command** — `worktree → discover → plan → build → review` — gating only on the two decisions that are actually yours: **the design direction**, and **"go"**. Everything in between is automatic.
+A Claude Code plugin: **`/ship`** takes a feature from **idea to merged in one command** — `worktree → discover → plan → build → review` — gating only on the two decisions that are actually yours: **locking the storyboard**, and **"go"** on the plan. Everything in between is automatic.
 
 It's opinionated. Built for a hands-off, PM-style workflow: you stay in your lane (product, design, taste, scope); the machine handles the mechanics and only stops at the two gates.
 
 ## What it does
 
-- **Two gates, only two.** Design direction (after discovery), then "go" (after planning). Everything else runs without you.
+- **Two gates, only two.** Lock the storyboard (after discovery), then "go" on the plan (after planning). Everything else runs without you.
 - **Sized to the ask.** Three lanes, ship picks: **express** (quick fix — no spec/plan, straight through to dev), **self-directed** (writes its own spec + plan, builds, reviews, merges — zero stops), **gated** (the two gates, when your taste is in play). Same worktree → merge → dev rails in all three; gates fire only when your answer would change what gets built.
-- **You read the meta, never the diff.** Every checkpoint auto-opens a condensed HTML card in your browser — a design spec, a go-card, and a **review card** at merge. Never "go read the PR."
+- **You read the meta, never the diff.** Every checkpoint auto-opens an HTML page in your browser — a **storyboard** (live mockups of the app, not a document), a one-screen **plan card**, and a **review card** at merge. Never "go read the PR."
 - **Gate notifications.** When a ship parks at a gate, a desktop notification taps you on the shoulder (Ghostty-native, with a macOS fallback) — so you can walk away.
 - **Stage-aware status line.** Which ship, what phase (`designing → planning → building → reviewing`), ships-in-flight, your context + weekly budget, effort level. A bold banner when a ship needs you.
 - **BUILD supervised, not shelled out.** Each closed-brief build task goes to an Opus subagent that owns one codex session end to end — brief, launch, patience, fix rounds, verdict — while the driver owns the plan, the diff review, the gates, and git. Orchestration stays inside Claude Code; codex still does the drafting.
@@ -16,7 +16,7 @@ It's opinionated. Built for a hands-off, PM-style workflow: you stay in your lan
 
 ## What's in the plugin
 
-- `skills/ship` — the pipeline playbook + the go-card / review-card templates + the design record.
+- `skills/ship` — the pipeline playbook + the storyboard / plan-card / review-card templates + the design record.
 - `skills/codex-supervisor` — how a subagent runs and babysits one codex task (bundled).
 - `skills/verify` — fresh read-only verification against the running app before merge.
 - `hooks/` — the gate desktop-notification hook.
@@ -25,7 +25,7 @@ It's opinionated. Built for a hands-off, PM-style workflow: you stay in your lan
 
 ## Requires
 
-Declared as plugin `dependencies` (Claude Code will prompt/handle them): **superpowers**, **ponytail**, **worktrunk** (`wt`). Optional but recommended: **impeccable** (HTML design sprints) and **pix** (image generation) for the discovery stage — without them, discovery degrades to text + CSS, still fine.
+Declared as plugin `dependencies` (Claude Code will prompt/handle them): **superpowers**, **ponytail**, **worktrunk** (`wt`). Optional but recommended: **impeccable** (the craft floor) and the **image-gen** skill (imagery inside a frame) for the discovery stage — without them, the storyboard is drawn from the product's stylesheet alone, still fine.
 
 ## Your standing stack stays personal
 

--- a/board/shipboard.mjs
+++ b/board/shipboard.mjs
@@ -288,7 +288,7 @@ function page(cards) {
     <li><code>/ship design</code> — full walk, your taste</li>
     <li><code>/ship next</code> — ship the Next column</li></ul></div>
   <div class="card"><h3>When you're needed</h3><ul>
-    <li><span class="chip c-gate"><span class="dot"></span>GATE 1</span> design direction</li>
+    <li><span class="chip c-gate"><span class="dot"></span>GATE 1</span> storyboard — lock it?</li>
     <li><span class="chip c-gate"><span class="dot"></span>GATE 2</span> go?</li>
     <li><span class="chip c-gate"><span class="dot"></span>REVIEW</span> merge? (it's running)</li>
     <li style="color:var(--ink3)">everything else is automatic</li></ul></div>

--- a/plugins/ship/hooks/gate-notify.sh
+++ b/plugins/ship/hooks/gate-notify.sh
@@ -9,7 +9,7 @@ stage_file="$root/.ship-stage"
 stage=$(head -1 "$stage_file" 2>/dev/null | tr -d ' \n')
 
 case "$stage" in
-  gate:1*) what="GATE 1 — design direction" ;;
+  gate:1*) what="GATE 1 — storyboard" ;;
   gate:2*) what="GATE 2 — go" ;;
   *) exit 0 ;;
 esac

--- a/plugins/ship/plugin.json
+++ b/plugins/ship/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship",
-  "description": "/ship \u2014 take a feature from idea to merged in one command: worktree \u2192 discover \u2192 plan \u2192 build \u2192 review, gating only on design direction and 'go'. Auto-opening HTML design/go/review cards, gate desktop notifications, a stage-aware status line, BUILD dispatched to Opus subagents that supervise codex runs, and fresh-agent verification before merge. Bundles codex-supervisor + verify.",
+  "description": "/ship \u2014 take a feature from idea to merged in one command: worktree \u2192 discover \u2192 plan \u2192 build \u2192 review, gating only on design direction and 'go'. Auto-opening HTML storyboard (live mockups), plan card and review card, gate desktop notifications, a stage-aware status line, BUILD dispatched to Opus subagents that supervise codex runs, and fresh-agent verification before merge. Bundles codex-supervisor + verify.",
   "author": {
     "name": "Pete McCarthy"
   },

--- a/plugins/ship/skills/pipeline/SKILL.md
+++ b/plugins/ship/skills/pipeline/SKILL.md
@@ -33,9 +33,9 @@ read-only — each *queued ship* forks as its own first act instead.
 - **`/ship express <tweak>`** — pins EXPRESS. The verb pins ceremony *down*, never
   safety down: a money path or a taste call promotes per the mid-flight rule regardless.
 - **`/ship design <idea>`** — pins GATED and mandates the full design workshop in
-  DISCOVER (pencil pass → rounds → lock → pen build-out → Pete iterates in pen →
-  go). The verb is Pete asserting taste is in
-  play; never downgrade it, however mechanical the work looks.
+  DISCOVER (storyboard → rounds → lock → HTML plan → go → spec → build). The verb is
+  Pete asserting taste is in play; never downgrade it, however mechanical the work
+  looks.
 - **`/ship next`** — ship the board's **Next column** as one batch (board-backed repos
   only; no board → say so and stop):
   1. **Sweep + enrich.** Pull every Next card; bring each up to standard anatomy
@@ -149,15 +149,17 @@ lands. Same posture at gates: notify, then keep doing non-gated work.
    landing-page-styled gate artifacts against the plain doc and kept the doc: "this is
    taking it far too radical an approach… maybe there's just a little bit of pruning."
    Cut any section that doesn't change a decision; shorter ledes, depth collapsed.
-2. **Two gates, at most.** GATE 1 = Pete's "go" on the pen design of record (DISCOVER runs as
-   presented rounds, each a hard stop — see stage 1) — always gated on the GATED lane. GATE 2 = go (after PLAN, via the go-card) — a hard stop
-   **only when the card carries a genuine call for Pete**: a PM tradeoff, a money path,
-   or something you judge he'd genuinely want to see before build. **A zero-call
-   go-card auto-passes** (Pete, 2026-07-28): render it, `open` it, narrate
-   "gate 2 auto-passed — nothing needed you," and keep going. Schema or auth alone
-   don't force the stop — stop only when you deem it genuinely necessary. Money paths
-   always stop. When a gate does fire, it is a **HARD STOP** — present the artifact and
-   wait.
+   **The storyboard is the one page that is not condensed prose: it is mockups**, and
+   its words are captions (stage 1). A storyboard that reads as a document has failed
+   (Pete, 2026-09-03: "more of a document and less like working with a designer").
+2. **Two gates, both his.** GATE 1 = Pete's lock on the storyboard (DISCOVER runs as
+   presented rounds, each a hard stop — see stage 1). GATE 2 = his "go" on the HTML
+   plan card (stage 2). **Both always fire on the GATED lane** (Pete, 2026-09-03:
+   storyboard, lock, plan, go, spec, build). This supersedes the 2026-07-28 rule that a
+   zero-call go-card auto-passes: a storyboard he iterated earns a plan he reads, and
+   the plan is one screen. SELF-DIRECTED and EXPRESS render no cards and stop for
+   nobody; a money path stops on any lane. When a gate fires, it is a **HARD STOP** —
+   present the artifact and wait.
 
 **Pete's stack:** his global instructions carry the standing stack — flue · Cloudflare ·
 Convex · Clerk · Stripe · Next. Never re-ask it. **The repo's own `CLAUDE.md` /
@@ -302,109 +304,87 @@ sweeps the marker into commits otherwise (incidents: Worktrees). Never build on 
 - For any visual/UI feature, invoke `impeccable` and follow its Setup (context.mjs —
   the repo's PRODUCT.md/DESIGN.md are the visual authority): a new surface or
   replacement look routes through its `shape`/new-work path; a refinement stays on the
-  incumbent world. Use `/image-gen` for imagery freely — the spec *is* the prototype.
+  incumbent world. Use `/image-gen` freely for imagery inside a frame.
   *Transplant:* a surface the reference owns gets none of this. Its design is the
-  reference bundle; the spec names the reference component (the i18n id, the chunk,
-  the class strings) and says "lift", and the workshop below runs only for the repo's
-  own surfaces. A ship that touches nothing of the repo's own skips pen entirely and
-  gates on the board alone.
+  reference bundle; its frame in the storyboard is the lifted markup (the i18n id, the
+  chunk and the class strings named in the caption), and the workshop below runs only
+  for the repo's own surfaces. A ship that touches nothing of the repo's own still
+  storyboards — Pete sees where the lifted thing sits in the app — and locks on that.
   **Ground the design in the live product**: a subagent walks the running app /
   deployed URL over `/browse` and reports the real theme/CSS with screenshots;
   design from those, never from in-repo mockups (incidents: Design).
-- **DISCOVER is a design workshop, not a handoff.** The first thing Pete sees is
-  never a finished spec — it's a working session, opened the way a designer opens one:
-  **ONE .pen file per ship** — `specs/designs/pen/YYYY-MM-DD-<slug>.pen` holds the
-  whole design phase as frames: the direction pencils, then the chosen design at
-  full fidelity. Pete flips between designs side by side in one document, deletes
-  the frames he doesn't like, iterates the survivor — and PLAN reads that one file.
-  Never scatter a ship's design across multiple .pen files.
-  1. **Pencil pass — rough directions first.** Open with 2–4 cheap, throwaway
-     directions, each a NAMED FRAME in the ship's one .pen file — **impeccable
-     briefs, pen draws**: run impeccable's context first, then
-     `pen --repo <project> --in/--out <the ship's .pen> --prompt "<direction
-     briefs, one frame per direction>" --prompt-file <live-product screenshot>
-     --export <png>` so pen's agent designs from PRODUCT.md/DESIGN.md and the real
-     product (the DISCOVER grounding screenshots), never from generic taste; embed
-     the per-frame exports in the HTML board (`02-exploration-visual-designs`,
-     side by side). Judge exports by eye against craft-floor taste — never lint a
-     pencil; impeccable's deterministic checks stay on the HTML spec and built UI.
-     No pen → sketch directly in HTML.
-     Present the board with the open questions a designer would actually bring
-     ("went denser on B, unsure about the nav, which tone?") — never a fait
-     accompli. Write `gate:1`, fire the gate notification, `open` the board, end
-     the turn with `needs input:` ("workshop round 1 — reactions?").
-     **HARD STOP** — every round is one.
-  2. **Workshop rounds.** Pete reacts; revise the frames + board in place — minutes
-     per round, not a re-spec — re-`open`, end the turn with `needs input:` again.
-     Push back where taste warrants it: a designer with no opinions is a renderer.
-     Loop until Pete locks a direction ("go with B", "lock it").
-  3. **Lock → pen builds it out, same file.** On the lock, drive pen to add the
-     locked direction as HIGH-FIDELITY frames of every specced surface to the SAME
-     .pen (`pen --repo <project> --in/--out <the ship's .pen> --prompt "<locked
-     direction, full surface inventory, real copy>" --prompt-file <grounding
-     screenshots>`), PNG exports beside it (`--export`, one per surface). Discarded
-     pencil frames are Pete's to delete — never prune them for him. **The pen file
-     is the DESIGN OF RECORD from here on** — committed on the branch, it travels
-     with the ship.
-  4. **Hand it to Pete where pen actually looks.** The Pen app's dashboard lists
-     ONLY its home folder — repo paths are invisible there, and an invisible
-     design is a dead workshop. Copy the working file to
-     `~/Library/Mobile Documents/com~apple~CloudDocs/Pencil/ship/<slug>.pen`
-     (create `ship/`; give it a human name, e.g. "homezero 404 — empty lot.pen")
-     and `open -a Pen "<that copy>"` so it's on his canvas and in his Recents.
-     End the turn with `needs input:` ("design is in pen — iterate there, say go
-     when it's right"). He edits at his own pace, in pen's own UI, no driver
-     round-trips. **The Pencil-folder copy is the live one while he iterates.**
-  5. **His "go" harvests the design.** Copy the Pencil-folder file BACK over
-     `specs/designs/pen/YYYY-MM-DD-<slug>.pen`, commit it, re-export the PNGs —
-     **whatever the file says at "go" IS the design**; never build from the
-     pre-iteration exports. The go IS GATE 1. Leave his Pencil copy in place
-     (it's his; a later express round harvests it again the same way).
-  6. **Go → spec.** Produce the thin HTML spec: the scope contract wrapped around
-     the pen exports (embed them) plus everything a comp can't carry — copy as
-     data, routes, behavior, states, a11y. `open` it for the record; no re-gate.
-- **Commit every gate artifact to the branch before you fire the gate** (board, spec,
-  pen file, go-card). A parked ship with uncommitted work looks disposable to another
+- **DISCOVER is a storyboard, not a document** (Pete, 2026-09-03). The first thing he
+  sees is the app: an HTML page that is mostly mockups of the screens the feature
+  touches, the way a designer opens a session by putting comps on the table. He reads
+  it like a storyboard, reacts, and you redraw. Nothing in DISCOVER is a spec; the
+  spec is written after his go (stage 2).
+  1. **Round 1 — the storyboard.** One file per ship,
+     `specs/designs/YYYY-MM-DD-<slug>.html` in the docs home, from
+     `reference/storyboard.html` (contract below). Each frame is a live HTML mockup of
+     one screen or state at the size it ships — the window, not a cropped component:
+     the sidebar, the titlebar, the new thing in place — drawn in the product's own
+     stylesheet and tokens. A transplant frame is the lifted markup. Where a direction
+     is genuinely open, draw it as two or three frames of the same screen side by side
+     (`02-exploration-visual-designs`), never as prose options. The words on the page
+     are captions: one line under each frame saying what is new in it, and the two or
+     three questions a designer would actually bring ("went denser on B, unsure about
+     the nav, which tone?"). Recon, consults and the reuse audit go in one collapsed
+     block at the foot, for the record; they never sit above a frame. No TL;DR essay,
+     no section per research finding, no fait accompli. Write `gate:1`, commit, fire
+     the gate notification, `open` the storyboard, end the turn with `needs input:`
+     ("storyboard round 1 — reactions?"). **HARD STOP** — every round is one.
+  2. **Rounds.** Pete reacts; redraw the frames in place — minutes per round, not a
+     re-spec. A frame he killed is deleted, never greyed out. Re-`open`, end the turn
+     with `needs input:` again. Push back where taste warrants it: a designer with no
+     opinions is a renderer. Loop until he locks it ("this is it", "lock it", "yes").
+  3. **Lock = GATE 1.** Commit the storyboard as it stands: **it is the design of
+     record from here on.** Every frame left in it ships; nothing not in it does. Log
+     the direction to decision memory, then straight into PLAN.
+  Pen (the Pencil app) is no longer the default. When Pete asks to take a frame into
+  pen, put it there, let him iterate, and harvest the result back into the frame
+  before the lock; the storyboard stays the single design of record either way.
+- **Commit every gate artifact to the branch before you fire the gate** (storyboard,
+  plan card). A parked ship with uncommitted work looks disposable to another
   session's cleanup sweep, and one nearly lost its spec that way (incidents: Worktrees).
-- The spec lives in the repo's docs home (`specs/` or `docs/`, whichever it uses) —
-  e.g. `specs/designs/YYYY-MM-DD-<slug>.html`. **The driver authors boards, briefs,
-  and spec prose inline** (taste is the deliverable, never dispatched); pen authors
-  the comps.
-- **Spec shape:** `14-research-feature-explainer` body (TL;DR first, collapsible
-  depth); the pen exports are the mockups; flows are diagrams
-  (`13-flowchart-diagram`).
-- A trivial visual change where multiple directions would be noise may collapse the
-  workshop to one board + one confirm — never to zero showings on the GATED lane.
-  A non-visual GATED ship (pure product tradeoff, no UI) skips pen and gates on the
-  board alone.
+- **The driver draws the frames and writes the captions inline** (taste is the
+  deliverable, never dispatched). Codex never draws a storyboard.
+- A trivial visual change where several frames would be noise may collapse the
+  storyboard to one frame + one confirm — never to zero showings on the GATED lane.
+  A non-visual GATED ship (pure product tradeoff, no UI) has no storyboard; it gates
+  on a one-screen board in the `14-research-feature-explainer` shape: TL;DR first,
+  the one question that matters, depth collapsed.
 
-### 2 · PLAN — automatic  → marker: `plan`, then `gate:2` (or straight through)
+### 2 · PLAN — the plan Pete says go on  → marker: `plan`, then `gate:2`
 
-- Write `plan`. Invoke `superpowers:writing-plans` for ONE execution plan covering the
-  **entire spec** — never sliced into phases. **The pen exports are the design source
-  of truth**: the plan's UI tasks reference the export image for each surface (path,
-  not prose description) and plan to match it. Run `ponytail` as the *waste* critic,
-  not a scope critic — it cuts reinvention and gold-plating, never specced scope.
-  *Transplant:* ponytail's ladder stops above the reference. A wrapper, a class, a
-  token or an element the reference's markup carries is never waste, however empty it
-  looks (the padding lives in it); "shortest working diff" applies to the repo's own
-  code only. Save
-  the markdown plan to the docs home (e.g. `specs/plans/YYYY-MM-DD-<slug>.md`).
+- Write `plan`. Run `ponytail` as the *waste* critic, not a scope critic — it cuts
+  reinvention and gold-plating, never a frame Pete locked. *Transplant:* ponytail's
+  ladder stops above the reference. A wrapper, a class, a token or an element the
+  reference's markup carries is never waste, however empty it looks (the padding
+  lives in it); "shortest working diff" applies to the repo's own code only.
+- **Consult a domain expert again only for a question the plan raises and the
+  storyboard didn't settle** — schema shape, index or migration order, an API's real
+  constraint, an auth boundary. Same rules as DISCOVER's consult: harness subagent, a
+  question not a task, the driver decides. **On SELF-DIRECTED — which skips DISCOVER's
+  storyboard — this is the lane's only consult**, so a stack question that would change
+  the plan gets asked here or nowhere.
+- **Render the plan card** from `reference/go-card.html` (contract below): the locked
+  storyboard in one glance, then what gets built as a punch list in plain English
+  (one line per piece of work, in build order), the cut list, his calls with your
+  recommendation, the risk line, and "go". Commit it, `open` it.
+- **GATE 2 is his go, always, on the GATED lane** (Two principles). Write `gate:2`,
+  fire the gate notification, end the turn with `needs input:` ("go?"). **HARD STOP.**
+  SELF-DIRECTED renders no card and stops for nobody.
+- **His go → spec it out.** Only now does the machine-facing writing happen: invoke
+  `superpowers:writing-plans` for ONE execution plan covering the **entire
+  storyboard** — never sliced into phases — saved to the docs home
+  (`specs/plans/YYYY-MM-DD-<slug>.md`). It carries everything a frame can't: copy as
+  data, routes, behaviour, states, a11y, test cases, and for each UI task the frame it
+  must match (`<storyboard>.html#<frame-id>`, never a prose description of the frame).
+  Pete never reads it. A change he asks for after go is an express round, not a
+  re-plan.
 - **A task that computes from rows another code path writes gets one end-to-end test
   through the real writer** — not just unit tests over hand-built rows, which pass while
   the production writers produce garbage (incidents: Design).
-- **Consult a domain expert again only for a question the plan raises and the spec
-  didn't settle** — schema shape, index or migration order, an API's real constraint,
-  an auth boundary. Same rules as DISCOVER's consult: harness subagent, a question not
-  a task, the driver decides. **On SELF-DIRECTED — which skips DISCOVER's workshop —
-  this is the lane's only consult**, so a stack question that would change the plan
-  gets asked here or nowhere.
-- Render the HTML **go-card** from `reference/go-card.html` (contract below) and
-  `open` it.
-- **Gate or go:** if the card carries a genuine call (PM tradeoff, money path, your
-  judgment says he'd want to see it) — write `gate:2`, fire the gate notification, end
-  the turn with `needs input:` ("go?"). **HARD STOP.** Otherwise **auto-pass**: narrate
-  "gate 2 auto-passed — nothing needed you" and continue to BUILD.
 
 ### 3 · BUILD — automatic  → marker: `build:N:M` (N done of M tasks)
 
@@ -433,9 +413,11 @@ sweeps the marker into commits otherwise (incidents: Worktrees). Never build on 
   parallelize 5 verifiers.
 - `ponytail` posture; `superpowers:verification-before-completion` before claiming any
   task done — actually run it; `superpowers:systematic-debugging` on a red test.
-- **UI-writing briefs carry the pen comp and the craft floor** — every dispatch that
-  writes UI names the surface's pen export (`specs/designs/pen/…png`) as the comp to
-  match, and — since codex has no impeccable installed — tells codex to read
+- **UI-writing briefs carry the storyboard frame and the craft floor** — every
+  dispatch that writes UI names the frame to match
+  (`specs/designs/<storyboard>.html#<frame-id>`; codex reads the frame's markup and
+  CSS, which is why a frame beats a PNG), and — since codex has no impeccable
+  installed — tells codex to read
   `~/.claude/skills/impeccable/reference/craft-floor.md` and honor its checks and bans.
   *Transplant:* a brief that touches a reference surface carries the reference path,
   the component to lift (grep the bundle for the id, take the class strings and the
@@ -477,18 +459,18 @@ sweeps the marker into commits otherwise (incidents: Worktrees). Never build on 
   impeccable's deterministic detector over the branch's changed UI files
   (`node ~/.claude/skills/impeccable/scripts/detect.mjs --json <files>` — local, no
   network), then walks the built surfaces and judges them **side-by-side against the
-  pen design of record** (screenshot each built surface next to its pen export —
-  impeccable's approved-comp critique: hero and sections as their own crops, never one
-  full-page thumbnail) plus the GATE 1 spec and the craft-floor checklist (contrast,
-  depth, spacing, type, motion, states, copy, and the bans). The review card shows the
-  pen-vs-built pairs — Pete reviews the design he iterated against the thing that got
-  built. Bounded per impeccable's own ceiling: one batched round, one confirm, no
+  storyboard** (screenshot each built surface next to its frame rendered at the same
+  size — impeccable's approved-comp critique: hero and sections as their own crops,
+  never one full-page thumbnail) plus the craft-floor checklist (contrast, depth,
+  spacing, type, motion, states, copy, and the bans). The review card shows the
+  frame-vs-built pairs — Pete reviews the storyboard he locked against the thing that
+  got built. Bounded per impeccable's own ceiling: one batched round, one confirm, no
   open-ended polish loops. **Report only — the driver owns every fix**; check
   `git status` the moment the round lands, because nothing enforces read-only at the
   tool layer (incidents: Dispatch). Driver triages: real gaps fixed before the card,
   nits land on the card for Pete. *Transplant:* for a reference surface the pair is
   the reference product beside ours (the repo's own tree audit and its screenshots),
-  never a pen export, and a visible difference is a finding whatever the checks say.
+  never a frame, and a visible difference is a finding whatever the checks say.
 - **Put it in front of Pete, running.** For any visual/interactive feature, boot the
   worktree's dev server **detached, never through a bounded pipe** (`nohup npm run dev >
   dev.log 2>&1 &`, then curl-probe — a `| head -50` has SIGPIPE'd a server mid-verify)
@@ -577,20 +559,42 @@ gh issue create -R peteknowsai/ship --label ship-retro --title "retro: <one-line
 **Most runs teach nothing — skip silently.** Never invent a lesson. Don't gate
 `result:` on this.
 
-## The go-card contract (GATE 2 artifact)
+## The storyboard contract (GATE 1 artifact)
+
+Render `reference/storyboard.html` — a page that is the app, not a page about it:
+
+- **Frames** — one per screen or state, live HTML at ship size, in the product's own
+  stylesheet: a repo that ships one links it by relative path from the docs home
+  (cells: the three grok sheets under `web/public/`); anything else inlines the tokens
+  it uses. Each frame is authored as a `<template>` and mounted into its own iframe by
+  the page's script, so the product's sheet styles the frame and nothing else, `:root`
+  tokens resolve, and a hover, an open menu or a tab works where the feature has one,
+  so Pete can poke it. Directions in play are sibling frames of the same screen.
+- **Captions** — one line per frame: what is new in it. A transplant frame's caption
+  names the reference component it lifts.
+- **The questions** — two or three, the ones a designer would bring, each with the
+  pick you'd make. Never a recommendation dressed as a question.
+- **For the record** — one collapsed block at the foot: recon, consults, reuse audit,
+  surface liveness. Never above a frame.
+
+No TL;DR, no research sections, no scope contract, no plan: the page is the mockups.
+
+## The plan card contract (GATE 2 artifact)
 
 Render `reference/go-card.html` filled with the meta only — one screen (a
-`16-implementation-plan` boiled down to its decision surface):
+`16-implementation-plan` boiled down to what he says go on):
 
-- **What gets built** — one line of scope.
+- **The storyboard** — the locked page embedded scaled-down in one glance, linked.
+- **What gets built** — the punch list: one plain-English line per piece of work, in
+  build order, five to twelve lines. Not files, not tasks numbered for a machine.
 - **Ponytail's cut-list** — what was dropped, and why.
-- **Pete's 1–3 calls** — each a PM tradeoff *with your recommendation*. Zero calls →
-  the gate auto-passes (see Two principles); the card is still rendered for the record.
+- **Pete's 1–3 calls** — each a PM tradeoff *with your recommendation*. Zero calls is
+  fine; the card still stops for his go.
 - **Risk** — one line.
-- **Mockup thumbnail** — if visual, from the design spec.
 - **Go** — one line.
 
-It is the *only* thing Pete reads before a build starts. Never make him read the plan.
+It is the *only* thing Pete reads before a build starts. The execution plan is written
+after his go and he never reads it.
 
 ## The review card (REVIEW artifact)
 
@@ -671,7 +675,7 @@ Desktop session:
 
 At a gate, three things fire so Pete notices whether he's watching or away:
 
-1. **Status line** — the `gate:N` marker shows `✋ <slug> — design?/go?` in bold amber.
+1. **Status line** — the `gate:N` marker shows `✋ <slug> — storyboard?/go?` in bold amber.
 2. **FleetView bucket** — the turn ends with a `needs input:` line → the row jumps to
    *awaiting input*.
 3. **Desktop notification** — the gate Stop-hook fires a Ghostty notification

--- a/plugins/ship/skills/pipeline/reference/go-card.html
+++ b/plugins/ship/skills/pipeline/reference/go-card.html
@@ -3,11 +3,13 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Go-card — {{SLUG}}</title>
+<title>Plan — {{SLUG}}</title>
 <!--
-  /ship GATE 2 template. Fill the {{SLOTS}}, write to specs/plans/go-card-<slug>.html,
-  and `open` it. The meta only — one screen. If a section is empty (e.g. no calls),
-  drop the whole card rather than showing it empty. Keep it to what Pete acts on.
+  /ship GATE 2 template — the plan Pete says go on. Fill the {{SLOTS}}, write to
+  specs/plans/go-card-<slug>.html, and `open` it. One screen: the locked storyboard in
+  a glance, the punch list in plain English, the cut list, his calls, risk, go. If a
+  section is empty (e.g. no calls), drop the whole card rather than showing it empty.
+  The execution plan is written AFTER his go and he never reads it.
 -->
 <style>
   :root{--cream:#f6f1e7;--card:#fffdf8;--ink:#23262d;--slate:#5a5e6b;--mut:#8a8d99;
@@ -34,6 +36,11 @@
     border:1px solid #e7d6ad;border-radius:6px;padding:2px 9px;font-weight:600}
   .risk{font-weight:600;font-size:14px}
   .thumb{width:100%;border-radius:8px;border:1px solid var(--line);margin-top:6px}
+  .board{position:relative;border:1px solid var(--line);border-radius:8px;overflow:hidden;background:#f6f1e7}
+  .board iframe{display:block;border:0;width:1240px;height:1400px;transform:scale(.5);transform-origin:0 0;pointer-events:none}
+  .board a.open{position:absolute;right:10px;bottom:10px;font-size:13px;background:var(--card);
+    border:1px solid var(--line);border-radius:6px;padding:3px 10px;color:var(--ink);text-decoration:none}
+  ol.punch{margin:6px 0 0;padding-left:22px} ol.punch li{margin:6px 0}
   .go{text-align:center;font-family:Georgia,serif;font-size:20px;margin:24px 0 6px;font-weight:600}
   .foot{color:var(--mut);font-size:13px;margin-top:18px;text-align:center}
   code{background:#efe9dc;border-radius:5px;padding:1px 6px;font-size:13px;font-family:ui-monospace,Menlo,monospace}
@@ -42,18 +49,24 @@
 <body>
 <div class="wrap">
   <div class="kicker">║ Gate 2 — go ║ &nbsp;·&nbsp; {{SLUG}}</div>
-  <h1>The go-card</h1>
-  <p class="sub">The only thing you read before the build. The meta — not the plan.</p>
+  <h1>The plan</h1>
+  <p class="sub">The storyboard you locked, and what gets built from it. Say go.</p>
 
   <div class="card">
     <h2>What gets built</h2>
     <p class="scope">{{SCOPE_ONE_LINE}}</p>
+    <!-- five to twelve lines, plain English, build order; never files or task numbers -->
+    <ol class="punch">{{PUNCH_LIST_ITEMS}}</ol>
   </div>
 
-  <!-- MOCKUP: include only for visual features, else delete this card -->
+  <!-- STORYBOARD: the locked page, half scale, in one glance. Non-visual ship: delete
+       this card. The iframe's height is the storyboard's; set .board's height to half. -->
   <div class="card">
-    <h2>Mockup</h2>
-    <img class="thumb" src="{{MOCKUP_SRC}}" alt="design mockup">
+    <h2>The storyboard</h2>
+    <div class="board" style="height:700px">
+      <iframe src="{{STORYBOARD_RELATIVE_PATH}}" title="locked storyboard"></iframe>
+      <a class="open" href="{{STORYBOARD_RELATIVE_PATH}}">open it</a>
+    </div>
   </div>
 
   <div class="card cut">
@@ -62,7 +75,7 @@
   </div>
 
   <!-- CALLS: 1–3 of these. If none, replace this card with a single line:
-       "Nothing needs you — pure confirm." -->
+       "No calls — the storyboard settled everything." The card still waits for go. -->
   <div class="card">
     <h2>Your call</h2>
     <div class="call">
@@ -79,7 +92,7 @@
   </div>
 
   <div class="go">go &nbsp;·&nbsp; or change something?</div>
-  <p class="foot">Plan (machine-facing): <code>{{PLAN_PATH}}</code> · spec: <code>{{SPEC_PATH}}</code></p>
+  <p class="foot">Storyboard: <code>{{STORYBOARD_PATH}}</code> · the execution plan is written after go</p>
 </div>
 </body>
 </html>

--- a/plugins/ship/skills/pipeline/reference/incidents.md
+++ b/plugins/ship/skills/pipeline/reference/incidents.md
@@ -124,6 +124,12 @@ These are facts, not process — the process lives in SKILL.md.
   "Grounded in the live product" proves a surface *renders*, not that it's *current* —
   classify liveness (on the current design system? reachable from primary nav? touched by
   recent commits?) and name the chosen surface explicitly in the spec.
+- **The first design artifact read as a document, not a design** (Pete, 2026-09-03: "it's
+  more of a document and less like working with a designer who gives me HTML which is
+  mostly just mockups of the app"). Round 1 had a TL;DR, research sections and a scope
+  contract with the comps somewhere below. DISCOVER now opens with a storyboard — frames
+  of the app at ship size, captions, the questions — and the spec is written after his
+  go, never before.
 - **Idealized-input tests hide writer/reader contract drift.** Unit tests over hand-built
   rows passed while the real ledger writers produced garbage for two of three metrics
   (one always 100%, one always null); only the adversarial review caught it. A task that

--- a/plugins/ship/skills/pipeline/reference/storyboard.html
+++ b/plugins/ship/skills/pipeline/reference/storyboard.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Storyboard — {{SLUG}}</title>
+<!--
+  /ship GATE 1 template. Write to specs/designs/YYYY-MM-DD-<slug>.html in the docs home
+  and `open` it. The page IS the mockups: frames of the app at ship size, one caption
+  each, the two or three questions a designer would bring, and everything else folded
+  under "for the record" at the foot. No TL;DR, no research sections, no plan.
+
+  Authoring a frame:
+    <template data-frame="frame-id" data-title="…" data-w="1180" data-h="760">
+      <link rel="stylesheet" href="../../web/public/grok-shipped.css">   (the product's own sheet, relative to THIS file)
+      …the screen's markup, in the product's own classes and tokens…
+    </template>
+  The script below mounts each template into its own iframe (srcdoc), so the product's
+  stylesheet styles the frame and nothing else, :root tokens resolve, and hovers, menus
+  and tabs inside the frame work. A transplant frame is the lifted markup, verbatim.
+  Directions in play: several <template>s with the same data-screen, drawn side by side.
+  Round N: bump data-round on <body>, delete frames Pete killed (never grey them out).
+-->
+<style>
+  :root{--cream:#f6f1e7;--card:#fffdf8;--ink:#23262d;--slate:#5a5e6b;--mut:#8a8d99;
+    --line:#e3dccb;--amber:#c8892b;--amber-soft:#f3ead6;}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--cream);color:var(--ink);
+    font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
+    -webkit-font-smoothing:antialiased;padding:32px 24px 80px}
+  .wrap{max-width:1240px;margin:0 auto}
+  .kicker{font-size:12px;letter-spacing:.18em;text-transform:uppercase;color:var(--amber);font-weight:700}
+  h1{font-family:Georgia,serif;font-size:30px;line-height:1.1;margin:6px 0 2px;font-weight:600}
+  .sub{color:var(--slate);margin:0 0 20px}
+  .sub b{color:var(--ink)}
+
+  /* one screen; sibling directions sit in a row */
+  .screen{margin:26px 0 8px}
+  .screen h2{font-family:Georgia,serif;font-size:18px;margin:0 0 8px;font-weight:600}
+  .row{display:flex;gap:18px;align-items:flex-start;overflow-x:auto;padding-bottom:6px}
+  figure.frame{margin:0;flex:1 1 0;min-width:0}
+  figure.frame .stage{position:relative;background:#111;border:1px solid var(--line);
+    border-radius:10px;overflow:hidden;box-shadow:0 10px 30px rgba(35,38,45,.12)}
+  figure.frame iframe{display:block;border:0;background:#111;transform-origin:0 0}
+  figcaption .tag{display:inline-block;font-size:11px;letter-spacing:.12em;text-transform:uppercase;
+    background:var(--amber-soft);color:#7a5a18;border:1px solid #e7d6ad;border-radius:6px;padding:0 7px;
+    font-weight:700;margin-right:6px;vertical-align:1px}
+  figcaption{margin:8px 2px 0;color:var(--slate);font-size:14px}
+  figcaption b{color:var(--ink)}
+  figcaption .ref{display:block;color:var(--mut);font-size:12px;font-family:ui-monospace,Menlo,monospace;margin-top:2px}
+
+  .card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:18px 22px;margin:26px 0 14px}
+  .card h2{font-family:Georgia,serif;margin:0 0 10px;text-transform:uppercase;color:var(--mut);
+    font-weight:700;font-size:12px;letter-spacing:.14em}
+  .q{border-left:3px solid var(--amber);padding:8px 0 8px 14px;margin:10px 0}
+  .q p{margin:0}
+  .q .pick{display:inline-block;margin-top:4px;font-size:13px;background:var(--amber-soft);color:#7a5a18;
+    border:1px solid #e7d6ad;border-radius:6px;padding:1px 9px;font-weight:600}
+
+  details{margin-top:36px;color:var(--slate);font-size:14px}
+  summary{cursor:pointer;color:var(--mut);font-size:12px;letter-spacing:.14em;text-transform:uppercase;font-weight:700}
+  details ul{padding-left:18px}
+  .foot{color:var(--mut);font-size:13px;margin-top:22px;text-align:center}
+  .foot code{background:#efe9dc;border-radius:5px;padding:1px 6px;font-size:12px;font-family:ui-monospace,Menlo,monospace}
+</style>
+</head>
+<body data-round="1">
+<div class="wrap">
+  <div class="kicker">║ Storyboard · round <span data-round-no>1</span> ║ &nbsp;·&nbsp; {{SLUG}}</div>
+  <h1>{{FEATURE_TITLE}}</h1>
+  <p class="sub">{{ONE_LINE_WHAT_IT_IS}} &nbsp;·&nbsp; <b>reactions?</b></p>
+
+  <!-- ONE .screen PER SCREEN OR STATE. Frames are mounted from the <template>s below;
+       the figure's data-mount names the template. Sibling directions: several figures
+       in one .row, tagged A / B / C in the caption. A single direction drops the tag. -->
+  <section class="screen">
+    <h2>{{SCREEN_1_NAME}}</h2>
+    <div class="row">
+      <figure class="frame" data-mount="{{FRAME_1_ID}}">
+        <div class="stage"></div>
+        <figcaption><span class="tag">A</span><b>{{FRAME_1_WHAT_IS_NEW}}</b>
+          <span class="ref">{{FRAME_1_REFERENCE_OR_BLANK}}</span></figcaption>
+      </figure>
+      <figure class="frame" data-mount="{{FRAME_2_ID}}">
+        <div class="stage"></div>
+        <figcaption><span class="tag">B</span><b>{{FRAME_2_WHAT_IS_NEW}}</b></figcaption>
+      </figure>
+    </div>
+  </section>
+
+  <div class="card">
+    <h2>What I'd ask you</h2>
+    <div class="q"><p>{{QUESTION_1}}</p><span class="pick">I'd pick: {{PICK_1}}</span></div>
+    <div class="q"><p>{{QUESTION_2}}</p><span class="pick">I'd pick: {{PICK_2}}</span></div>
+  </div>
+
+  <details>
+    <summary>For the record</summary>
+    <ul>
+      <li>{{RECON_FINDING}}</li>
+      <li>{{REUSE_AUDIT_RESULT}}</li>
+      <li>{{SURFACE_LIVENESS}}</li>
+      <li>{{EXPERT_CONSULT_IF_ANY}}</li>
+    </ul>
+  </details>
+  <p class="foot">Lock it and the plan follows. Frames not on this page do not ship. <code>{{BRANCH}}</code></p>
+</div>
+
+<!-- ============ FRAMES ============ one <template> per frame, mounted above -->
+<template data-frame="{{FRAME_1_ID}}" data-w="1180" data-h="760">
+  <link rel="stylesheet" href="{{PRODUCT_STYLESHEET_RELATIVE_PATH}}">
+  <style>html,body{margin:0;height:100%}</style>
+  {{FRAME_1_MARKUP}}
+</template>
+<template data-frame="{{FRAME_2_ID}}" data-w="1180" data-h="760">
+  <link rel="stylesheet" href="{{PRODUCT_STYLESHEET_RELATIVE_PATH}}">
+  <style>html,body{margin:0;height:100%}</style>
+  {{FRAME_2_MARKUP}}
+</template>
+
+<script>
+// Mount every <template data-frame> into the figure that names it, scaled to fit.
+(function () {
+  const templates = new Map();
+  for (const t of document.querySelectorAll('template[data-frame]')) templates.set(t.dataset.frame, t);
+  const mounted = [];
+  for (const fig of document.querySelectorAll('figure.frame[data-mount]')) {
+    const t = templates.get(fig.dataset.mount);
+    const stage = fig.querySelector('.stage');
+    if (!t || !stage) continue;
+    const w = Number(t.dataset.w || 1180), h = Number(t.dataset.h || 760);
+    const f = document.createElement('iframe');
+    f.width = w; f.height = h; f.title = fig.dataset.mount;
+    f.srcdoc = '<!doctype html><html><head><meta charset="utf-8"><base href="' + location.href + '"></head><body>' + t.innerHTML + '</body></html>';
+    stage.prepend(f);
+    mounted.push({ f, stage, w, h });
+  }
+  function fit() {
+    for (const m of mounted) {
+      const s = Math.min(1, m.stage.clientWidth / m.w);
+      m.f.style.transform = 'scale(' + s + ')';
+      m.stage.style.height = Math.round(m.h * s) + 'px';
+    }
+  }
+  fit(); addEventListener('resize', fit);
+  const r = document.body.dataset.round; const el = document.querySelector('[data-round-no]');
+  if (r && el) el.textContent = r;
+})();
+</script>
+</body>
+</html>

--- a/plugins/ship/statusline.sh
+++ b/plugins/ship/statusline.sh
@@ -40,11 +40,16 @@ if [ "$HAS_JQ" -eq 1 ]; then
   current_dir=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // "~"' 2>/dev/null | sed "s|^$HOME|~|g")
   cc_version=$(echo "$input" | jq -r '.version // ""' 2>/dev/null)
   effort=$(echo "$input" | jq -r '.effort.level // ""' 2>/dev/null)
+  model_name=$(echo "$input" | jq -r '.model.display_name // .model.id // ""' 2>/dev/null)
   context_pct=$(echo "$input" | jq -r '.context_window.used_percentage // 0' 2>/dev/null)
   context_pct=$(printf "%.0f" "$context_pct" 2>/dev/null)
 else
-  current_dir="~"; cc_version=""; effort=""; context_pct=0
+  current_dir="~"; cc_version=""; effort=""; context_pct=0; model_name=""
 fi
+
+# The context-window size never changes mid-session, so "(1M context)" is a constant
+# taking up room. Drop any trailing parenthetical: "Opus 5 (1M context)" -> "Opus 5".
+model_name=$(printf '%s' "$model_name" | sed 's/ *([^)]*)//g')
 
 # ---- git: branch only (the slug / fallback identity) ----
 git_branch=""
@@ -89,10 +94,15 @@ if [ "$cache_stale" -eq 1 ] && [ "$HAS_JQ" -eq 1 ]; then
     echo "$fresh_data" | jq -e '.seven_day' >/dev/null 2>&1 && echo "$fresh_data" > "$usage_cache"
   fi
 fi
+scoped_pct=""
+scoped_label=""
 if [ -f "$usage_cache" ] && [ "$HAS_JQ" -eq 1 ]; then
-  weekly_val=$(jq -r '.seven_day.utilization // empty' "$usage_cache" 2>/dev/null)
+  weekly_val=$(jq -r '(.limits[]? | select(.kind == "weekly_all") | .percent) // .seven_day.utilization // empty' "$usage_cache" 2>/dev/null)
   [ -n "$weekly_val" ] && [ "$weekly_val" != "null" ] && weekly_pct=$(printf "%.0f" "$weekly_val" 2>/dev/null)
   weekly_resets=$(jq -r '.seven_day.resets_at // empty' "$usage_cache" 2>/dev/null)
+  # model-scoped weekly bucket (e.g. Fable) — label comes from the API, not hardcoded
+  scoped_pct=$(jq -r '(.limits[]? | select(.kind == "weekly_scoped") | .percent) // empty' "$usage_cache" 2>/dev/null)
+  scoped_label=$(jq -r '(.limits[]? | select(.kind == "weekly_scoped") | .scope.model.display_name) // empty' "$usage_cache" 2>/dev/null | tr '[:upper:]' '[:lower:]')
 fi
 
 # ---- update available? (cached 30m; render only when actually behind) ----
@@ -148,6 +158,11 @@ weekly_color() {
   elif [ "${weekly_pct:-0}" -ge 50 ]; then c '38;5;215'
   else c '38;5;158'; fi
 }
+scoped_color() {
+  if [ "${scoped_pct:-0}" -ge 80 ]; then c '38;5;203'
+  elif [ "${scoped_pct:-0}" -ge 50 ]; then c '38;5;215'
+  else c '38;5;158'; fi
+}
 
 # ============================ render ============================
 # Line 1 — identity only: which ship (or repo·branch) + ships-in-flight count.
@@ -155,7 +170,7 @@ weekly_color() {
 is_gate=0; phase=""
 if [ -n "$ship_stage" ]; then
   case "$ship_stage" in
-    gate:1*) printf "$(gate_c)✋ %s — design?$(rst)" "$ship_slug"; is_gate=1; phase="$(stage_bar design)" ;;
+    gate:1*) printf "$(gate_c)✋ %s — storyboard?$(rst)" "$ship_slug"; is_gate=1; phase="$(stage_bar design)" ;;
     gate:2*) printf "$(gate_c)✋ %s — go?$(rst)" "$ship_slug"; is_gate=1; phase="$(stage_bar plan)" ;;
     discover*) printf "$(ship_c)🚢 %s$(rst)" "$ship_slug"; phase="$(stage_bar design)" ;;
     plan*)     printf "$(ship_c)🚢 %s$(rst)" "$ship_slug"; phase="$(stage_bar plan)" ;;
@@ -175,10 +190,22 @@ printf "\n"
 
 # Line 2 — phase (when in a ship), then the gauges + effort.
 [ -n "$phase" ] && printf "$(phase_c)%s$(rst)  " "$phase"
+[ -n "$model_name" ] && printf "$(c '38;5;183')🤖 %s$(rst)  " "$model_name"
 printf "$(context_color)🧠 %d%%$(rst)" "${context_pct:-0}"
 if [ -n "$weekly_pct" ]; then
-  printf "  $(weekly_color)📊 %d%%$(rst)" "$weekly_pct"
-  if [ "${weekly_pct:-0}" -ge 50 ]; then
+  # Quota reads as initials, not a chart icon and a spelled-out model name:
+  # "O 1% · F 0%". The letters ARE the labels, so they carry their own meaning
+  # at a glance and cost four columns instead of twelve.
+  # ponytail: the API exposes no Opus-only bucket — weekly_all covers every model,
+  # so O is really "everything", which is Opus plus a rounding error in practice.
+  # If a second scoped model ever appears, split it out rather than folding it in.
+  printf "  "
+  if [ -n "$scoped_pct" ] && [ -n "$scoped_label" ]; then
+    scoped_initial=$(printf '%s' "${scoped_label:0:1}" | tr '[:lower:]' '[:upper:]')
+    printf "$(scoped_color)%s %d%%$(rst) $(c '38;5;245')·$(rst) " "$scoped_initial" "$scoped_pct"
+  fi
+  printf "$(weekly_color)O %d%%$(rst)" "$weekly_pct"
+  if [ "${weekly_pct:-0}" -ge 50 ] || [ "${scoped_pct:-0}" -ge 50 ]; then
     rs=$(format_reset "$weekly_resets")
     [ -n "$rs" ] && printf " $(c '38;5;245')↻ %s$(rst)" "$rs"
   fi

--- a/specs/designs/2026-09-03-storyboard-first.html
+++ b/specs/designs/2026-09-03-storyboard-first.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Storyboard first — /ship design phase</title>
+<style>
+  :root { --bg:#faf9f7; --ink:#1a1a1a; --muted:#6b6b6b; --line:#e4e1db; --accent:#b4552d; --good:#2d7a4f; --card:#fff; --code-bg:#f0eee9; --amber-soft:#f3ead6; }
+  @media (prefers-color-scheme: dark) { :root { --bg:#161513; --ink:#e8e6e1; --muted:#9a978f; --line:#2e2c28; --accent:#e07a4a; --good:#5bbd8a; --card:#1e1d1a; --code-bg:#26241f; --amber-soft:#3a2f1a; } }
+  * { box-sizing:border-box; margin:0 }
+  body { background:var(--bg); color:var(--ink); font:16px/1.6 -apple-system,"SF Pro Text",Segoe UI,sans-serif; max-width:960px; margin:0 auto; padding:3rem 1.5rem 6rem }
+  h1 { font-size:1.9rem; line-height:1.2; letter-spacing:-.02em; margin-bottom:.4rem }
+  h2 { font-size:1.2rem; margin:2.6rem 0 .9rem; padding-top:1.3rem; border-top:1px solid var(--line) }
+  p { margin:.6rem 0 } .kicker { color:var(--accent); font-weight:600; font-size:.8rem; text-transform:uppercase; letter-spacing:.08em }
+  .sub { color:var(--muted); font-size:.95rem }
+  .tldr { background:var(--card); border:1px solid var(--line); border-left:4px solid var(--accent); border-radius:8px; padding:1rem 1.3rem; margin:1.6rem 0 }
+  code { background:var(--code-bg); border-radius:4px; padding:.1em .35em; font-size:.85em; font-family:"SF Mono",ui-monospace,Menlo,monospace }
+  table { border-collapse:collapse; width:100%; margin:1rem 0; font-size:.9rem } th { text-align:left; font-size:.72rem; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); padding:.5rem .7rem; border-bottom:2px solid var(--line) }
+  td { padding:.55rem .7rem; border-bottom:1px solid var(--line); vertical-align:top }
+  .flow { display:flex; gap:8px; flex-wrap:wrap; margin:1rem 0 }
+  .step { flex:1 1 120px; background:var(--card); border:1px solid var(--line); border-radius:8px; padding:.6rem .8rem; font-size:.88rem }
+  .step b { display:block; font-size:.72rem; text-transform:uppercase; letter-spacing:.06em; color:var(--accent) }
+  .step.you { border-color:var(--accent); background:var(--amber-soft) }
+  /* the live example storyboard */
+  .board { border:1px solid var(--line); border-radius:10px; overflow:hidden; background:#f6f1e7; color:#23262d; padding:18px 20px }
+  .board .k { font-size:11px; letter-spacing:.18em; text-transform:uppercase; color:#c8892b; font-weight:700 }
+  .board h3 { font-family:Georgia,serif; font-size:22px; margin:4px 0 2px; font-weight:600 }
+  .board .s { color:#5a5e6b; font-size:14px; margin:0 0 14px }
+  .row { display:flex; gap:14px } figure { margin:0; flex:1 }
+  .stage { background:#111; border-radius:8px; overflow:hidden; position:relative } .stage iframe { display:block; border:0; transform-origin:0 0 }
+  figcaption { font-size:13px; color:#5a5e6b; margin-top:6px } figcaption b { color:#23262d }
+  .tag { display:inline-block; font-size:10px; letter-spacing:.12em; text-transform:uppercase; background:#f3ead6; color:#7a5a18; border:1px solid #e7d6ad; border-radius:5px; padding:0 6px; font-weight:700; margin-right:6px }
+  .q { border-left:3px solid #c8892b; padding:4px 0 4px 12px; margin:14px 0 0; font-size:14px; color:#23262d }
+  .pick { display:inline-block; font-size:12px; background:#f3ead6; color:#7a5a18; border:1px solid #e7d6ad; border-radius:5px; padding:0 8px; font-weight:600; margin-top:3px }
+  .good { color:var(--good); font-weight:600 }
+</style>
+</head>
+<body>
+<div class="kicker">/ship · design phase · 2026-09-03</div>
+<h1>Storyboard first</h1>
+<p class="sub">The first thing you see in DISCOVER is the app, not a document about it.</p>
+
+<div class="tldr">
+  <p><b>What changed.</b> DISCOVER now opens with a <b>storyboard</b>: one HTML page that is mostly live mockups of the screens the feature touches, at the size they ship, in the product's own stylesheet. One caption per frame, two or three designer questions, everything else folded away at the foot. You react, I redraw, until you say "this is it". That lock is gate 1.</p>
+  <p>Then PLAN renders a one-screen <b>plan card</b>: the storyboard in a glance and a plain-English punch list of what gets built. You say <b>go</b>. That is gate 2, and it always waits for you now. Only after go do I write the machine-facing execution plan and start the build.</p>
+  <p>Pen is no longer the default. The storyboard is the design of record; a frame goes to pen only when you ask.</p>
+</div>
+
+<h2>The flow</h2>
+<div class="flow">
+  <div class="step"><b>discover</b>recon, grounding, consults</div>
+  <div class="step you"><b>storyboard · you</b>frames of the app; reactions, rounds</div>
+  <div class="step you"><b>lock · gate 1</b>"this is it"</div>
+  <div class="step"><b>plan</b>ponytail cut, punch list</div>
+  <div class="step you"><b>go · gate 2</b>the plan card, one screen</div>
+  <div class="step"><b>spec</b>execution plan, machine-facing</div>
+  <div class="step"><b>build · review</b>codex app-server, verify, land</div>
+</div>
+
+<h2>What a round 1 looks like</h2>
+<p class="sub">A live example of the template, with a toy app. A real one links the repo's own stylesheet (cells: the three grok sheets) and the frames are the real screens.</p>
+<div class="board">
+  <div class="k">║ Storyboard · round 1 ║ &nbsp;·&nbsp; documents-tab</div>
+  <h3>A document tab on the info pane</h3>
+  <p class="s">a bot's page sits on the stage beside its computer &nbsp;·&nbsp; <b>reactions?</b></p>
+  <div class="row">
+    <figure><div class="stage" data-mount="a"></div><figcaption><span class="tag">A</span><b>three icon tabs above the stage</b><br>Computer · Browser · Document, the lit one amber</figcaption></figure>
+    <figure><div class="stage" data-mount="b"></div><figcaption><span class="tag">B</span><b>a segmented control inside the stage header</b><br>denser; the page keeps 40px more height</figcaption></figure>
+  </div>
+  <div class="q">Tabs above (A) or a control inside the header (B)? A reads at a glance from the chat; B keeps the page taller. <br><span class="pick">I'd pick: A</span></div>
+  <div class="q">The earlier documents: a footer list under the page, or a menu on the tab? <br><span class="pick">I'd pick: the footer list</span></div>
+  <p style="margin:14px 0 0;font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:#8a8d99;font-weight:700">▸ for the record</p>
+</div>
+
+<template data-frame="a">
+  <style>html,body{margin:0;height:100%;background:#1f1f1f;color:#ddd;font:13px -apple-system,sans-serif}.win{display:flex;height:100%}.side{width:170px;background:#181818;border-right:1px solid #2a2a2a;padding:10px}.side div{padding:5px 6px;border-radius:6px}.side .on{background:#2a2a2a}.chat{flex:1;padding:14px;border-right:1px solid #2a2a2a}.bub{background:#2a2a2a;border-radius:10px;padding:8px 10px;max-width:260px;margin:8px 0}.pane{width:300px;padding:10px}.tabs{display:flex;gap:6px}.tabs span{padding:4px 9px;border-radius:6px;background:#262626;color:#aaa}.tabs .lit{background:#c8892b;color:#111;font-weight:600}.stage{margin-top:8px;height:200px;background:#fff;color:#222;border-radius:8px;padding:14px;font-family:Georgia,serif}.foot{margin-top:8px;color:#888;font-size:11px}</style>
+  <div class="win"><div class="side"><div>CELLS</div><div class="on">Marlow</div><div>Tamsin</div><div>Orrin</div></div>
+  <div class="chat"><div class="bub">write up the launch plan as a page</div><div class="bub" style="margin-left:40px">Done, it's on the stage.</div></div>
+  <div class="pane"><div class="tabs"><span>▣ Computer</span><span>◎ Browser</span><span class="lit">▤ Document</span></div>
+  <div class="stage"><b>Launch plan</b><br><span style="font-size:11px">Three weeks, two cells, one page.</span></div>
+  <div class="foot">earlier · Roadmap (yesterday) · Notes (Mon)</div></div></div>
+</template>
+<template data-frame="b">
+  <style>html,body{margin:0;height:100%;background:#1f1f1f;color:#ddd;font:13px -apple-system,sans-serif}.win{display:flex;height:100%}.side{width:170px;background:#181818;border-right:1px solid #2a2a2a;padding:10px}.side div{padding:5px 6px;border-radius:6px}.side .on{background:#2a2a2a}.chat{flex:1;padding:14px;border-right:1px solid #2a2a2a}.bub{background:#2a2a2a;border-radius:10px;padding:8px 10px;max-width:260px;margin:8px 0}.pane{width:300px;padding:10px}.hdr{display:flex;justify-content:space-between;align-items:center;background:#262626;border-radius:8px 8px 0 0;padding:6px 8px}.seg{display:flex;background:#1a1a1a;border-radius:6px;padding:2px}.seg span{padding:2px 7px;border-radius:5px;color:#aaa;font-size:11px}.seg .lit{background:#c8892b;color:#111;font-weight:600}.stage{height:240px;background:#fff;color:#222;border-radius:0 0 8px 8px;padding:14px;font-family:Georgia,serif}</style>
+  <div class="win"><div class="side"><div>CELLS</div><div class="on">Marlow</div><div>Tamsin</div><div>Orrin</div></div>
+  <div class="chat"><div class="bub">write up the launch plan as a page</div><div class="bub" style="margin-left:40px">Done, it's on the stage.</div></div>
+  <div class="pane"><div class="hdr"><span style="font-size:11px;color:#aaa">Marlow's stage</span><div class="seg"><span>Computer</span><span>Browser</span><span class="lit">Document</span></div></div>
+  <div class="stage"><b>Launch plan</b><br><span style="font-size:11px">Three weeks, two cells, one page.</span></div></div></div>
+</template>
+<script>
+(function(){const T={};for(const t of document.querySelectorAll('template[data-frame]'))T[t.dataset.frame]=t;const M=[];
+for(const st of document.querySelectorAll('.stage[data-mount]')){const t=T[st.dataset.mount];if(!t)continue;const f=document.createElement('iframe');f.width=760;f.height=380;
+f.srcdoc='<!doctype html><html><head><meta charset="utf-8"></head><body>'+t.innerHTML+'</body></html>';st.appendChild(f);M.push({f,st,w:760,h:380});}
+function fit(){for(const m of M){const s=Math.min(1,m.st.clientWidth/m.w);m.f.style.transform='scale('+s+')';m.st.style.height=Math.round(m.h*s)+'px';}}fit();addEventListener('resize',fit);})();
+</script>
+
+<h2>Before and after</h2>
+<table>
+<tr><th>Stage</th><th>Was</th><th>Now</th></tr>
+<tr><td>DISCOVER round 1</td><td>an HTML spec: TL;DR, research, scope, comps somewhere below; pen frames in the Pencil app</td><td>a storyboard: frames of the app at ship size, captions, the questions; research collapsed at the foot</td></tr>
+<tr><td>Gate 1</td><td>your "go" on the pen file</td><td>your lock on the storyboard ("this is it")</td></tr>
+<tr><td>PLAN</td><td>markdown execution plan first, then a go-card that auto-passed with zero calls</td><td>a plan card: the storyboard in a glance plus a plain-English punch list; always waits for go</td></tr>
+<tr><td>Spec</td><td>written before the plan, HTML, for you</td><td>written after go, markdown, machine-facing; you never read it</td></tr>
+<tr><td>Build briefs</td><td>point codex at a pen PNG</td><td>point codex at the frame (<code>storyboard.html#frame-id</code>); it reads the markup and CSS</td></tr>
+<tr><td>Design QA</td><td>built surface beside the pen export</td><td>built surface beside the frame at the same size</td></tr>
+<tr><td>Status line</td><td><code>✋ slug — design?</code></td><td><code>✋ slug — storyboard?</code>, then <code>go?</code></td></tr>
+</table>
+
+<h2>How a frame works</h2>
+<p>Each frame is a <code>&lt;template&gt;</code> in the storyboard file. A short script mounts it into its own iframe, so the product's stylesheet styles the frame and nothing else, the theme's root tokens resolve, and a hover, a menu or a tab inside the frame works. In cells a frame links <code>web/public/grok-shipped.css</code> and the dark theme sheet by relative path, and a <code>sand-</code> or <code>ui-</code> frame is the lifted markup itself, so the mockup is already what gets built.</p>
+
+<h2>Checked</h2>
+<table>
+<tr><td>Worktrunk</td><td class="good">0.63.0 to 0.76.0</td><td><code>wt switch --create … --no-cd --format=json -y</code>, <code>wt remove -f</code> and <code>wt merge</code> all still exist; a probe fork returned its path in the JSON and was removed cleanly</td></tr>
+<tr><td>Status line</td><td class="good">works</td><td>the plugin copy was behind the live one at <code>~/.claude/statusline.sh</code> (model name, the two quota buckets) and is now the same file; a probe worktree at <code>gate:1</code> rendered the amber banner and <code>build:2:5</code> the stage bar</td></tr>
+<tr><td>Gate hook</td><td class="good">fires</td><td>at <code>gate:2</code> it took the macOS notification path in a backgrounded session</td></tr>
+<tr><td>Frame mechanism</td><td class="good">renders</td><td>a probe storyboard in cells mounted two frames side by side; a box inside one took <code>.ui-1q4ynmn</code> from the shipped sheet and computed a 10px radius</td></tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
DISCOVER's first artifact is a storyboard (live frames of the app, captions, questions), gate 1 is Pete's lock on it, PLAN renders a one-screen plan card that always waits for go, and the execution plan is written after go. Pen demoted to opt-in; build briefs and design QA point at storyboard frames. Status line synced from the live copy; gate 1 reads "storyboard?".

Spec: specs/designs/2026-09-03-storyboard-first.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLNkRdvNHHvB3AQ7Hmnwd6